### PR TITLE
Make use of OwnerReferences while referring to parent object

### DIFF
--- a/cluster-autoscaler/.gitignore
+++ b/cluster-autoscaler/.gitignore
@@ -1,6 +1,8 @@
 cluster-autoscaler
 cluster_autoscaler
 .cover
+.vscode
+bin
 
 # Vim-related files
 [._]*.s[a-w][a-z]


### PR DESCRIPTION
This PR makes use of the OwnerReferences while finding the MachineDeployment object from MachineObject. 