### PR TITLE
UPSTREAM:<carry> Tolerate worker specific labels and small memory difference while balancing nodegroup

### DIFF
--- a/cluster-autoscaler/utils/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/utils/nodegroupset/compare_nodegroups.go
@@ -32,6 +32,9 @@ const (
 	// MaxFreeDifferenceRatio describes how free resources (allocatable - daemon and system pods)
 	// can differ between groups in the same NodeGroupSet
 	MaxFreeDifferenceRatio = 0.05
+	// MaxMemoryDifferenceInKiloBytes describes how much memory
+	// capacity can differ but still be considered equal.
+	MaxMemoryDifferenceInKiloBytes = 128000
 )
 
 func compareResourceMapsWithTolerance(resources map[apiv1.ResourceName][]resource.Quantity,
@@ -73,14 +76,28 @@ func IsNodeInfoSimilar(n1, n2 *schedulercache.NodeInfo) bool {
 			free[res] = append(free[res], freeRes)
 		}
 	}
-	// For capacity we require exact match.
-	// If this is ever changed, enforcing MaxCoresTotal and MaxMemoryTotal limits
-	// as it is now may no longer work.
-	for _, qtyList := range capacity {
-		if len(qtyList) != 2 || qtyList[0].Cmp(qtyList[1]) != 0 {
+
+	for kind, qtyList := range capacity {
+		if len(qtyList) != 2 {
 			return false
 		}
+		switch kind {
+		case apiv1.ResourceMemory:
+			// For memory capacity we allow a small tolerance
+			memoryDifference := math.Abs(float64(qtyList[0].Value()) - float64(qtyList[1].Value()))
+			if memoryDifference > MaxMemoryDifferenceInKiloBytes {
+				return false
+			}
+		default:
+			// For other capacity types we require exact match.
+			// If this is ever changed, enforcing MaxCoresTotal limits
+			// as it is now may no longer work.
+			if qtyList[0].Cmp(qtyList[1]) != 0 {
+				return false
+			}
+		}
 	}
+
 	// For allocatable and free we allow resource quantities to be within a few % of each other
 	if !compareResourceMapsWithTolerance(allocatable, MaxAllocatableDifferenceRatio) {
 		return false

--- a/cluster-autoscaler/utils/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/utils/nodegroupset/compare_nodegroups.go
@@ -118,6 +118,12 @@ func IsNodeInfoSimilar(n1, n2 *schedulercache.NodeInfo) bool {
 			if label == kubeletapis.LabelZoneRegion {
 				continue
 			}
+			if label == kubeletapis.LabelGardenerWorkerGroup {
+				continue
+			}
+			if label == kubeletapis.LabelGardenerWorkerPool {
+				continue
+			}
 			labels[label] = append(labels[label], value)
 		}
 	}

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_labels.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_labels.go
@@ -17,12 +17,13 @@ limitations under the License.
 package apis
 
 const (
-	LabelHostname           = "kubernetes.io/hostname"
-	LabelZoneFailureDomain  = "failure-domain.beta.kubernetes.io/zone"
-	LabelMultiZoneDelimiter = "__"
-	LabelZoneRegion         = "failure-domain.beta.kubernetes.io/region"
-
-	LabelInstanceType = "beta.kubernetes.io/instance-type"
+	LabelHostname            = "kubernetes.io/hostname"
+	LabelZoneFailureDomain   = "failure-domain.beta.kubernetes.io/zone"
+	LabelMultiZoneDelimiter  = "__"
+	LabelZoneRegion          = "failure-domain.beta.kubernetes.io/region"
+	LabelGardenerWorkerGroup = "worker.garden.sapcloud.io/group"
+	LabelGardenerWorkerPool  = "worker.gardener.cloud/pool"
+	LabelInstanceType        = "beta.kubernetes.io/instance-type"
 
 	LabelOS   = "beta.kubernetes.io/os"
 	LabelArch = "beta.kubernetes.io/arch"


### PR DESCRIPTION
**What this PR does / why we need it**: CA now tolerates a 128Ki of memory difference and worker-specific labels while balancing the nodegroups. 

**Which issue(s) this PR fixes**:
Fixes [#234](https://github.com/gardener/machine-controller-manager/issues/234)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator|developer
-->
```improvement operator
Ignore worker specific labels and 128Ki of memory difference while balancing nodegroups.
```
