### PR TITLE
Skip node not managed by mcm

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/gardener/autoscaler/cluster-autoscaler/cloudprovider"
 	"github.com/gardener/autoscaler/cluster-autoscaler/config/dynamic"
 	"github.com/gardener/autoscaler/cluster-autoscaler/utils/errors"
@@ -109,6 +110,10 @@ func (mcm *mcmCloudProvider) NodeGroups() []cloudprovider.NodeGroup {
 
 // NodeGroupForNode returns the node group for the given node.
 func (mcm *mcmCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.NodeGroup, error) {
+	if len(node.Spec.ProviderID) == 0 {
+		glog.Warningf("Node %v has no providerId", node.Name)
+		return nil, nil
+	}
 	ref, err := ReferenceFromProviderID(mcm.mcmManager, node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
@@ -169,6 +174,7 @@ func ReferenceFromProviderID(m *McmManager, id string) (*Ref, error) {
 			break
 		}
 	}
+	
 	if Name == "" {
 		return nil, fmt.Errorf("Could not find any machine corresponds to node %+v", id)
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -114,9 +114,15 @@ func (mcm *mcmCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 		glog.Warningf("Node %v has no providerId", node.Name)
 		return nil, nil
 	}
+    
 	ref, err := ReferenceFromProviderID(mcm.mcmManager, node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
+	}
+
+	if ref == nil {
+ 		glog.Infof("Skipped node %v, not managed by this controller", node.Spec.ProviderID)
+		return nil, nil 
 	}
 
 	return mcm.mcmManager.GetMachineDeploymentForMachine(ref)
@@ -176,7 +182,8 @@ func ReferenceFromProviderID(m *McmManager, id string) (*Ref, error) {
 	}
 	
 	if Name == "" {
-		return nil, fmt.Errorf("Could not find any machine corresponds to node %+v", id)
+		// Could not find any machine corresponds to node %+v", id
+		return nil, nil 
 	}
 	return &Ref{
 		Name:      Name,

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -177,7 +177,7 @@ func (m *McmManager) GetMachineDeploymentForMachine(machine *Ref) (*MachineDeplo
 }
 
 //Cleanup does nothing at the moment.
-//TODO: Enable cleanup menthod for graceful shutdown.
+//TODO: Enable cleanup method for graceful shutdown.
 func (m *McmManager) Cleanup() {
 	return
 }
@@ -326,7 +326,7 @@ func (m *McmManager) DeleteMachines(machines []*Ref) error {
 		break
 	}
 
-	glog.V(2).Infof("MachineDeployment %s size decreased to %q", commonMachineDeployment.Name, mdclone.Spec.Replicas)
+	glog.V(2).Infof("MachineDeployment %s size decreased to %d", commonMachineDeployment.Name, mdclone.Spec.Replicas)
 
 	return nil
 }


### PR DESCRIPTION
With the autoscaler deployed on a cluster with existing nodes and also nodes managed by [machine-controller-manager](https://github.com/gardener/machine-controller-manager), scaling up is not working because it was returning an error when the node is not part of a machine deployment. 

Like the [AWS provider](https://github.com/gardener/autoscaler/blob/machine-controller-manager/cluster-autoscaler/cloudprovider/aws/aws_cloud_provider.go#L79) we should actually skip those nodes.
 