### PR TITLE
Use zone-info while scaling-up the node-group from zero

### DIFF
--- a/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
+++ b/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/types.go
@@ -946,6 +946,7 @@ type AzureVirtualMachineProperties struct {
 	OsProfile       AzureOSProfile
 	NetworkProfile  AzureNetworkProfile
 	AvailabilitySet AzureSubResource
+	Zone            *int
 }
 
 // AzureHardwareProfile is specifies the hardware settings for the virtual machine.

--- a/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/types.go
+++ b/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1/types.go
@@ -946,6 +946,7 @@ type AzureVirtualMachineProperties struct {
 	OsProfile       AzureOSProfile       `json:"osProfile,omitempty"`
 	NetworkProfile  AzureNetworkProfile  `json:"networkProfile,omitempty"`
 	AvailabilitySet AzureSubResource     `json:"availabilitySet,omitempty"`
+	Zone            *int                 `json:"zone,omitempty"`
 }
 
 // AzureHardwareProfile is specifies the hardware settings for the virtual machine.
@@ -1267,14 +1268,14 @@ type PacketMachineClassList struct {
 
 // PacketMachineClassSpec is the specification of a cluster.
 type PacketMachineClassSpec struct {
-	Facility     []string           `json:"facility"`
-	MachineType  string             `json:"machineType"`
-	BillingCycle string             `json:"billingCycle"`
-	OS           string             `json:"OS"`
-	ProjectID    string             `json:"projectID"`
-	Tags         []string  `json:"tags,omitempty"`
+	Facility     []string `json:"facility"`
+	MachineType  string   `json:"machineType"`
+	BillingCycle string   `json:"billingCycle"`
+	OS           string   `json:"OS"`
+	ProjectID    string   `json:"projectID"`
+	Tags         []string `json:"tags,omitempty"`
 	SSHKeys      []string `json:"sshKeys,omitempty"`
-	UserData     string             `json:"userdata,omitempty"`
+	UserData     string   `json:"userdata,omitempty"`
 
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty"`
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This PR uses the zone-information for scaling the node-groups from zero.

**Which issue(s) this PR fixes**:
Fixes #34 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Autoscaler uses zone-information while scaling-up the node-group from zero
```
