### PR TITLE
Ignore the node-group with maxSize set to 0

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -428,11 +428,11 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 		return nil, cloudprovider.ErrNotImplemented
 	}
 
-	labels := make(map[string]string) 
+	labels := make(map[string]string)
 	taints := make([]apiv1.Taint, 0)
 
 	if nodeTemplateSpec.ObjectMeta.Labels != nil {
-		labels = nodeTemplateSpec.ObjectMeta.Labels 
+		labels = nodeTemplateSpec.ObjectMeta.Labels
 	}
 	if nodeTemplateSpec.Spec.Taints != nil {
 		taints = nodeTemplateSpec.Spec.Taints
@@ -442,7 +442,7 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 		InstanceType: &instance,
 		Region:       region,
 		Zone:         "undefined", // will be implemented in MCM
-		Labels:       labels, 
+		Labels:       labels,
 		Taints:       taints,
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**: This PR ignores the node-group with maxSize set to zero.
Earlier autoscaler could not scale-up the healthy worker-pool if there exists another worker-pool with min=max=0.  
   - This happened, as autoscaler tried to find the NodeTemplate of the 0:0 worker pool, but as `NodeTemplateInfo` is not implemented for all providers, it used to fail for providers other than AWS and Azure. This failure blocks the scale-up for other healthy worker-pools as well, due to the nature of CA.

With this change, we simply ignore the worker-pools which have maxSize set to 0.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Cluster Autoscaler ignores the worker pools with maxSize set to 0.
```
