### PR TITLE
UPSTREAM:<carry>: Avoid checking controller references while draining the node

### DIFF
--- a/cluster-autoscaler/simulator/drain.go
+++ b/cluster-autoscaler/simulator/drain.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/gardener/autoscaler/cluster-autoscaler/utils/drain"
 	apiv1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"github.com/gardener/autoscaler/cluster-autoscaler/utils/drain"
 	client "k8s.io/client-go/kubernetes"
 	schedulercache "k8s.io/kubernetes/pkg/scheduler/cache"
 )
@@ -70,7 +70,7 @@ func DetailedGetPodsForMove(nodeInfo *schedulercache.NodeInfo, skipNodesWithSyst
 		false,
 		skipNodesWithSystemPods,
 		skipNodesWithLocalStorage,
-		true,
+		false, // TODO: Revendor the clients.
 		client,
 		minReplicaCount,
 		time.Now())


### PR DESCRIPTION
**What this PR does / why we need it**: This PR avoids checking controller references while draining. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Avoid checking controller references while draining the node.
```
