### PR TITLE
UPSTREAM:<carry> Ignore the topology based labels while comparing nodegroups

### DIFF
--- a/cluster-autoscaler/utils/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/utils/nodegroupset/compare_nodegroups.go
@@ -34,7 +34,7 @@ const (
 	MaxFreeDifferenceRatio = 0.05
 	// MaxMemoryDifferenceInKiloBytes describes how much memory
 	// capacity can differ but still be considered equal.
-	MaxMemoryDifferenceInKiloBytes = 128000
+	MaxMemoryDifferenceInKiloBytes = 256000000
 )
 
 func compareResourceMapsWithTolerance(resources map[apiv1.ResourceName][]resource.Quantity,
@@ -62,6 +62,15 @@ func IsNodeInfoSimilar(n1, n2 *schedulercache.NodeInfo) bool {
 	allocatable := make(map[apiv1.ResourceName][]resource.Quantity)
 	free := make(map[apiv1.ResourceName][]resource.Quantity)
 	nodes := []*schedulercache.NodeInfo{n1, n2}
+
+	const (
+		LabelGardenerWorkerGroup = "worker.garden.sapcloud.io/group"
+		LabelGardenerWorkerPool  = "worker.gardener.cloud/pool"
+		LabelZoneTopology        = "topology.kubernetes.io/zone"
+		LabelRegionTopology      = "topology.kubernetes.io/region"
+		LabelZoneCSIEBS          = "topology.ebs.csi.aws.com/zone"
+	)
+
 	for _, node := range nodes {
 		for res, quantity := range node.Node().Status.Capacity {
 			capacity[res] = append(capacity[res], quantity)
@@ -118,10 +127,19 @@ func IsNodeInfoSimilar(n1, n2 *schedulercache.NodeInfo) bool {
 			if label == kubeletapis.LabelZoneRegion {
 				continue
 			}
-			if label == kubeletapis.LabelGardenerWorkerGroup {
+			if label == LabelGardenerWorkerGroup {
 				continue
 			}
-			if label == kubeletapis.LabelGardenerWorkerPool {
+			if label == LabelGardenerWorkerPool {
+				continue
+			}
+			if label == LabelZoneTopology {
+				continue
+			}
+			if label == LabelRegionTopology {
+				continue
+			}
+			if label == LabelZoneCSIEBS {
 				continue
 			}
 			labels[label] = append(labels[label], value)

--- a/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_labels.go
+++ b/cluster-autoscaler/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_labels.go
@@ -17,16 +17,13 @@ limitations under the License.
 package apis
 
 const (
-	LabelHostname            = "kubernetes.io/hostname"
-	LabelZoneFailureDomain   = "failure-domain.beta.kubernetes.io/zone"
-	LabelMultiZoneDelimiter  = "__"
-	LabelZoneRegion          = "failure-domain.beta.kubernetes.io/region"
-	LabelGardenerWorkerGroup = "worker.garden.sapcloud.io/group"
-	LabelGardenerWorkerPool  = "worker.gardener.cloud/pool"
-	LabelInstanceType        = "beta.kubernetes.io/instance-type"
-
-	LabelOS   = "beta.kubernetes.io/os"
-	LabelArch = "beta.kubernetes.io/arch"
+	LabelHostname           = "kubernetes.io/hostname"
+	LabelZoneFailureDomain  = "failure-domain.beta.kubernetes.io/zone"
+	LabelMultiZoneDelimiter = "__"
+	LabelZoneRegion         = "failure-domain.beta.kubernetes.io/region"
+	LabelInstanceType       = "beta.kubernetes.io/instance-type"
+	LabelOS                 = "beta.kubernetes.io/os"
+	LabelArch               = "beta.kubernetes.io/arch"
 )
 
 // When the --failure-domains scheduler flag is not specified,


### PR DESCRIPTION
**What this PR does / why we need it**: With k8s 1.17, nodes are labeled with topology-based keywords. With this PR we ignore these labels while comparing the node groups.

**Which issue(s) this PR fixes**:
Partially fixes https://github.com/gardener/autoscaler/issues/31

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Add topology.kubernetes.io labels to be ignored when comparing similar node groups.
```
