### PR TITLE
Avoid scaling-down already terminating machines

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -343,10 +343,12 @@ func (machinedeployment *MachineDeployment) DeleteNodes(nodes []*apiv1.Node) err
 		belongs, err := machinedeployment.Belongs(node)
 		if err != nil {
 			return err
+		} else if !belongs {
+			return fmt.Errorf("%s belongs to a different machinedeployment than %s", node.Name, machinedeployment.Id())
 		}
 		ref, err := ReferenceFromProviderID(machinedeployment.mcmManager, node.Spec.ProviderID)
-		if belongs != true {
-			return fmt.Errorf("%s belongs to a different machinedeployment than %s", node.Name, machinedeployment.Id())
+		if err != nil {
+			return fmt.Errorf("Couldn't find the machine-name from provider-id %s", node.Spec.ProviderID)
 		}
 		machines = append(machines, ref)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: With this PR, we avoid scaling down the machines which are already being delelted.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/55

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Autoscaler avoids scaling down the machines which are already being terminated.
```
