### PR TITLE
Support new topology/zones labels

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -64,12 +64,6 @@ const (
 	conflictRetryInterval   = 5 * time.Second
 	// machinePriorityAnnotation is the annotation to set machine priority while deletion
 	machinePriorityAnnotation = "machinepriority.machine.sapcloud.io"
-	// labelFailureDomainZone is the deprecated label for failure domain zone used by kubernetes.io
-	// It has been deprecated in favor of (below) topology.kubernetes.io/zone label
-	// See: https://v1-18.docs.kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone
-	labelFailureDomainZone = "failure-domain.beta.kubernetes.io/zone"
-	// labelTopologyZone is the label for topology zone used by kubernetes.io
-	labelTopologyZone = "topology.kubernetes.io/zone"
 	// kindAWSMachineClass is the kind for machine class used by In-tree AWS provider
 	kindAWSMachineClass = "AWSMachineClass"
 	// kindAzureMachineClass is the kind for machine class used by In-tree Azure provider
@@ -557,10 +551,10 @@ func getZoneValueFromMCLabels(labels map[string]string) string {
 	var zone string
 
 	if labels != nil {
-		if value, exists := labels[labelTopologyZone]; exists {
+		if value, exists := labels[apiv1.LabelZoneFailureDomainStable]; exists {
 			// Prefer zone value from the new label
 			zone = value
-		} else if value, exists := labels[labelFailureDomainZone]; exists {
+		} else if value, exists := labels[apiv1.LabelZoneFailureDomain]; exists {
 			// Fallback to zone value from deprecated label if new lable value doesn't exist
 			zone = value
 		}
@@ -606,12 +600,20 @@ func buildGenericLabels(template *nodeTemplate, nodeName string) map[string]stri
 	result := make(map[string]string)
 	// TODO: extract from MCM
 	result[kubeletapis.LabelArch] = cloudprovider.DefaultArch
+	result[apiv1.LabelArchStable] = cloudprovider.DefaultArch
+
 	result[kubeletapis.LabelOS] = cloudprovider.DefaultOS
+	result[apiv1.LabelOSStable] = cloudprovider.DefaultOS
 
 	result[apiv1.LabelInstanceType] = template.InstanceType.InstanceType
+	result[apiv1.LabelInstanceTypeStable] = template.InstanceType.InstanceType
 
 	result[apiv1.LabelZoneRegion] = template.Region
+	result[apiv1.LabelZoneRegionStable] = template.Region
+
 	result[apiv1.LabelZoneFailureDomain] = template.Zone
+	result[apiv1.LabelZoneFailureDomainStable] = template.Zone
+
 	result[apiv1.LabelHostname] = nodeName
 	return result
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -26,19 +26,39 @@ import (
 )
 
 func TestBuildGenericLabels(t *testing.T) {
+	var (
+		instanceTypeC4Large = "c4.large"
+		regionUSEast1       = "us-east-1"
+		zoneUSEast1a        = "us-east-1a"
+		testHostName        = "test-hostname"
+	)
+
 	labels := buildGenericLabels(&nodeTemplate{
 		InstanceType: &instanceType{
-			InstanceType: "c4.large",
+			InstanceType: instanceTypeC4Large,
 			VCPU:         2,
 			MemoryMb:     3840,
 		},
-		Region: "us-east-1",
-	}, "sillyname")
-	assert.Equal(t, "us-east-1", labels[apiv1.LabelZoneRegion])
-	assert.Equal(t, "sillyname", labels[apiv1.LabelHostname])
-	assert.Equal(t, "c4.large", labels[apiv1.LabelInstanceType])
+		Region: regionUSEast1,
+		Zone:   zoneUSEast1a,
+	}, testHostName)
+
 	assert.Equal(t, cloudprovider.DefaultArch, labels[kubeletapis.LabelArch])
+	assert.Equal(t, cloudprovider.DefaultArch, labels[apiv1.LabelArchStable])
+
 	assert.Equal(t, cloudprovider.DefaultOS, labels[kubeletapis.LabelOS])
+	assert.Equal(t, cloudprovider.DefaultOS, labels[apiv1.LabelOSStable])
+
+	assert.Equal(t, instanceTypeC4Large, labels[apiv1.LabelInstanceType])
+	assert.Equal(t, instanceTypeC4Large, labels[apiv1.LabelInstanceTypeStable])
+
+	assert.Equal(t, regionUSEast1, labels[apiv1.LabelZoneRegion])
+	assert.Equal(t, regionUSEast1, labels[apiv1.LabelZoneRegionStable])
+
+	assert.Equal(t, zoneUSEast1a, labels[apiv1.LabelZoneFailureDomain])
+	assert.Equal(t, zoneUSEast1a, labels[apiv1.LabelZoneFailureDomainStable])
+
+	assert.Equal(t, testHostName, labels[apiv1.LabelHostname])
 }
 
 func TestGenerationOfCorrectZoneValueFromMCLabel(t *testing.T) {
@@ -52,21 +72,21 @@ func TestGenerationOfCorrectZoneValueFromMCLabel(t *testing.T) {
 
 	// Basic test to get zone value
 	resultingZone = getZoneValueFromMCLabels(map[string]string{
-		labelTopologyZone: zoneA,
+		apiv1.LabelZoneFailureDomainStable: zoneA,
 	})
 	assert.Equal(t, resultingZone, zoneA)
 
-	// Prefer labelTopologyZone label over labelFailureDomainZone
+	// Prefer LabelZoneFailureDomainStable label over LabelZoneFailureDomain
 	resultingZone = getZoneValueFromMCLabels(map[string]string{
-		labelTopologyZone:      zoneA,
-		labelFailureDomainZone: zoneB,
+		apiv1.LabelZoneFailureDomainStable: zoneA,
+		apiv1.LabelZoneFailureDomain:       zoneB,
 	})
 	assert.Equal(t, resultingZone, zoneA)
 
-	// Fallback to labelFailureDomainZone whne labelTopologyZone is not found
+	// Fallback to LabelZoneFailureDomain when LabelZoneFailureDomainStable is not found
 	resultingZone = getZoneValueFromMCLabels(map[string]string{
-		randomKey:              randomValue,
-		labelFailureDomainZone: zoneB,
+		randomKey:                    randomValue,
+		apiv1.LabelZoneFailureDomain: zoneB,
 	})
 	assert.Equal(t, resultingZone, zoneB)
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -40,3 +40,39 @@ func TestBuildGenericLabels(t *testing.T) {
 	assert.Equal(t, cloudprovider.DefaultArch, labels[kubeletapis.LabelArch])
 	assert.Equal(t, cloudprovider.DefaultOS, labels[kubeletapis.LabelOS])
 }
+
+func TestGenerationOfCorrectZoneValueFromMCLabel(t *testing.T) {
+	var (
+		resultingZone string
+		zoneA         = "zone-a"
+		zoneB         = "zone-b"
+		randomKey     = "random-key"
+		randomValue   = "random-value"
+	)
+
+	// Basic test to get zone value
+	resultingZone = getZoneValueFromMCLabels(map[string]string{
+		labelTopologyZone: zoneA,
+	})
+	assert.Equal(t, resultingZone, zoneA)
+
+	// Prefer labelTopologyZone label over labelFailureDomainZone
+	resultingZone = getZoneValueFromMCLabels(map[string]string{
+		labelTopologyZone:      zoneA,
+		labelFailureDomainZone: zoneB,
+	})
+	assert.Equal(t, resultingZone, zoneA)
+
+	// Fallback to labelFailureDomainZone whne labelTopologyZone is not found
+	resultingZone = getZoneValueFromMCLabels(map[string]string{
+		randomKey:              randomValue,
+		labelFailureDomainZone: zoneB,
+	})
+	assert.Equal(t, resultingZone, zoneB)
+
+	// When neither of the labels are found
+	resultingZone = getZoneValueFromMCLabels(map[string]string{
+		randomKey: randomValue,
+	})
+	assert.Equal(t, resultingZone, "")
+}


### PR DESCRIPTION
The old failure-domain label was deprecated in favour of topology/zone labels. This PR addresses this issue.
See: https://v1-18.docs.kubernetes.io/docs/reference/kubernetes-api/labels-annotations-taints/#failure-domainbetakubernetesiozone

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #68 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Support the latest zone label `topology.kubernetes.io/zone` in addition to the existing `failure-domain.beta.kubernetes.io/zone` while determining the zone for AWS machines.
```
```improvement user
Allow scaling up from zero using the latest stable zone, region, arch, OS, instanceType labels on node objects. 
```
