### PR TITLE
Use cached informers clients

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/core_client_builder.go
+++ b/cluster-autoscaler/cloudprovider/mcm/core_client_builder.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This file was copied and modified from the kubernetes/kubernetes project
+https://github.com/kubernetes/kubernetes/blob/release-1.8/pkg/controller/client_builder.go
+*/
+
+package mcm
+
+import (
+	clientgoclientset "k8s.io/client-go/kubernetes"
+	clientset "k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+
+	"k8s.io/klog"
+)
+
+// ClientBuilder allows you to get clients and configs for core controllers
+type CoreClientBuilder interface {
+	Config(name string) (*restclient.Config, error)
+	ConfigOrDie(name string) *restclient.Config
+	Client(name string) (clientset.Interface, error)
+	ClientOrDie(name string) clientset.Interface
+	ClientGoClient(name string) (clientgoclientset.Interface, error)
+	ClientGoClientOrDie(name string) clientgoclientset.Interface
+}
+
+// CoreControllerClientBuilder returns a fixed client with different user agents
+type CoreControllerClientBuilder struct {
+	// ClientConfig is a skeleton config to clone and use as the basis for each controller client
+	ClientConfig *restclient.Config
+}
+
+// Config lets you configure the client builder
+func (b CoreControllerClientBuilder) Config(name string) (*restclient.Config, error) {
+	clientConfig := *b.ClientConfig
+	return restclient.AddUserAgent(&clientConfig, name), nil
+}
+
+// ConfigOrDie either configures or die's while configuring
+func (b CoreControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {
+	clientConfig, err := b.Config(name)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return clientConfig
+}
+
+// Client builds a new client for clientBuilder
+func (b CoreControllerClientBuilder) Client(name string) (clientset.Interface, error) {
+	clientConfig, err := b.Config(name)
+	if err != nil {
+		return nil, err
+	}
+	return clientset.NewForConfig(clientConfig)
+}
+
+// ClientOrDie builds a client or die's
+func (b CoreControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
+	client, err := b.Client(name)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return client
+}
+
+// ClientGoClient builds a go client
+func (b CoreControllerClientBuilder) ClientGoClient(name string) (clientgoclientset.Interface, error) {
+	clientConfig, err := b.Config(name)
+	if err != nil {
+		return nil, err
+	}
+	return clientgoclientset.NewForConfig(clientConfig)
+}
+
+// ClientGoClientOrDie builds a go client or die's
+func (b CoreControllerClientBuilder) ClientGoClientOrDie(name string) clientgoclientset.Interface {
+	client, err := b.ClientGoClient(name)
+	if err != nil {
+		klog.Fatal(err)
+	}
+	return client
+}

--- a/cluster-autoscaler/cloudprovider/mcm/machine_client_builder.go
+++ b/cluster-autoscaler/cloudprovider/mcm/machine_client_builder.go
@@ -24,8 +24,8 @@ import (
 	"k8s.io/klog"
 )
 
-// ClientBuilder allows you to get clients and configs for controllers
-type ClientBuilder interface {
+// MachineClientBuilder allows you to get clients and configs for machine controllers
+type MachineClientBuilder interface {
 	// Config returns a new restclient.Config with the given user agent name.
 	Config(name string) (*restclient.Config, error)
 	// ConfigOrDie return a new restclient.Config with the given user agent
@@ -40,21 +40,21 @@ type ClientBuilder interface {
 	ClientOrDie(name string) clientset.Interface
 }
 
-// SimpleClientBuilder returns a fixed client with different user agents
-type SimpleClientBuilder struct {
+// MachineControllerClientBuilder returns a fixed client with different user agents
+type MachineControllerClientBuilder struct {
 	// ClientConfig is a skeleton config to clone and use as the basis for each controller client
 	ClientConfig *restclient.Config
 }
 
 // Config returns a new restclient.Config with the given user agent name.
-func (b SimpleClientBuilder) Config(name string) (*restclient.Config, error) {
+func (b MachineControllerClientBuilder) Config(name string) (*restclient.Config, error) {
 	clientConfig := *b.ClientConfig
 	return restclient.AddUserAgent(&clientConfig, name), nil
 }
 
 // ConfigOrDie return a new restclient.Config with the given user agent
 // name, or logs a fatal error.
-func (b SimpleClientBuilder) ConfigOrDie(name string) *restclient.Config {
+func (b MachineControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {
 	clientConfig, err := b.Config(name)
 	if err != nil {
 		klog.Fatal(err)
@@ -64,7 +64,7 @@ func (b SimpleClientBuilder) ConfigOrDie(name string) *restclient.Config {
 
 // Client returns a new clientset.Interface with the given user agent
 // name.
-func (b SimpleClientBuilder) Client(name string) (clientset.Interface, error) {
+func (b MachineControllerClientBuilder) Client(name string) (clientset.Interface, error) {
 	clientConfig, err := b.Config(name)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ func (b SimpleClientBuilder) Client(name string) (clientset.Interface, error) {
 // ClientOrDie returns a new clientset.Interface with the given user agent
 // name or logs a fatal error, destroying the computer and killing the
 // operator and programmer.
-func (b SimpleClientBuilder) ClientOrDie(name string) clientset.Interface {
+func (b MachineControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
 	if err != nil {
 		klog.Fatal(err)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR switches use from individual list calls to using cached informers. Definitely an important optimization we have missed. 

**Which issue(s) this PR fixes**:
Fixes #72 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```noteworthy operator
Switch to using cached informers to fetch cloud provider details more optimally.
```
```noteworthy user
Enable configuraiton of flags such as `control-apiserver-burst`, `control-apiserver-qps`, `target-apiserver-burst`, `target-apiserver-qps` and `min-resync-period` for kubernetes client configurations while fetching objects for MCM cloud provider.  
```
