### PR TITLE
Bugfix: Allow scaling down of machine with already lowered priority

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -797,9 +797,6 @@ func isMachineTerminating(machine *v1alpha1.Machine) bool {
 	if !machine.GetDeletionTimestamp().IsZero() {
 		klog.Infof("Machine %q is already being terminated, and hence skipping the deletion", machine.Name)
 		return true
-	} else if machine.Annotations != nil && machine.Annotations[machinePriorityAnnotation] == "1" {
-		klog.Infof("Machine %q 's priority is set to 1, we assume it to be triggered for deletion by autoscaler earlier, hence skipping deletion", machine.Name)
-		return true
 	}
 	return false
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/64

**Special notes for your reviewer**:
Please check the issue. The fix in line with changes suggested by @hardikdr 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Bug fix: Allow scaling down of machine with already lowered priority
```
/assign @AxiomSamarth 