### PR TITLE
[rel-v0.16] Avoids panics when VM type isn't found during scale from zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -628,7 +628,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 		if err != nil {
 			return nil, fmt.Errorf("Unable to fetch AWSMachineClass object %s, Error: %v", machineClass.Name, err)
 		}
-		awsInstance := aws.InstanceTypes[mc.Spec.MachineType]
+		awsInstance, exists := aws.InstanceTypes[mc.Spec.MachineType]
+		if !exists {
+			return nil, fmt.Errorf("Unable to fetch details for VM type %s", mc.Spec.MachineType)
+		}
 		instance = instanceType{
 			InstanceType: awsInstance.InstanceType,
 			VCPU:         awsInstance.VCPU,
@@ -642,7 +645,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 		if err != nil {
 			return nil, fmt.Errorf("Unable to fetch AzureMachineClass object %s, Error: %v", machineClass.Name, err)
 		}
-		azureInstance := azure.InstanceTypes[mc.Spec.Properties.HardwareProfile.VMSize]
+		azureInstance, exists := azure.InstanceTypes[mc.Spec.Properties.HardwareProfile.VMSize]
+		if !exists {
+			return nil, fmt.Errorf("Unable to fetch details for VM type %s", mc.Spec.Properties.HardwareProfile.VMSize)
+		}
 		instance = instanceType{
 			InstanceType: azureInstance.InstanceType,
 			VCPU:         azureInstance.VCPU,
@@ -666,7 +672,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 				return nil, fmt.Errorf("Unable to convert from %s to %s for %s, Error: %v", kindMachineClass, providerAWS, machinedeployment.Name, err)
 			}
 
-			awsInstance := aws.InstanceTypes[providerSpec.MachineType]
+			awsInstance, exists := aws.InstanceTypes[providerSpec.MachineType]
+			if !exists {
+				return nil, fmt.Errorf("Unable to fetch details for VM type %s", providerSpec.MachineType)
+			}
 			instance = instanceType{
 				InstanceType: awsInstance.InstanceType,
 				VCPU:         awsInstance.VCPU,
@@ -681,8 +690,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 			if err != nil {
 				return nil, fmt.Errorf("Unable to convert from %s to %s for %s, Error: %v", kindMachineClass, providerAzure, machinedeployment.Name, err)
 			}
-
-			azureInstance := aws.InstanceTypes[providerSpec.Properties.HardwareProfile.VMSize]
+			azureInstance, exists := azure.InstanceTypes[providerSpec.Properties.HardwareProfile.VMSize]
+			if !exists {
+				return nil, fmt.Errorf("Unable to fetch details for VM type %s", providerSpec.Properties.HardwareProfile.VMSize)
+			}
 			instance = instanceType{
 				InstanceType: azureInstance.InstanceType,
 				VCPU:         azureInstance.VCPU,


### PR DESCRIPTION
- Cluster autoscaler was trying to fetch VM details for AWS VMs instead of required Azure VMs for MCM (OOT) provider Azure. This lead to panics. Now, it fetches the details from the correct provider VM map.
- This PR also improves error handling in such scenarios to not panic.

**What this PR does / why we need it**:
Cherrypick of https://github.com/gardener/autoscaler/pull/77 on rel-v0.16

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/76

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix developer
Avoids panics when VM type isn't found during scale from zero
```
```bugfix developer
Fetches the VM from the correct map for MCM provider Azure and hence doesn't panic anymore
```
/invite @AxiomSamarth @ialidzhikov 