### PR TITLE
Do not return errors while fetching details for an unmanaged node

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -152,8 +152,8 @@ func (mcm *mcmCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 	}
 
 	var isManaged bool
-	for _, nodeGroup := range mcm.machinedeployments {
-		if nodeGroup.Id() == md.Id() {
+	for _, managedMachineDeployment := range mcm.machinedeployments {
+		if managedMachineDeployment.Id() == md.Id() {
 			isManaged = true
 			break
 		}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -28,6 +28,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
@@ -49,7 +50,7 @@ const (
 // Reference: https://github.com/gardener/machine-controller-manager
 type mcmCloudProvider struct {
 	mcmManager         *McmManager
-	machinedeployments []*MachineDeployment
+	machinedeployments map[types.NamespacedName]*MachineDeployment
 	resourceLimiter    *cloudprovider.ResourceLimiter
 }
 
@@ -80,7 +81,7 @@ func BuildMCM(opts config.AutoscalingOptions, do cloudprovider.NodeGroupDiscover
 func buildStaticallyDiscoveringProvider(mcmManager *McmManager, specs []string, resourceLimiter *cloudprovider.ResourceLimiter) (*mcmCloudProvider, error) {
 	mcm := &mcmCloudProvider{
 		mcmManager:         mcmManager,
-		machinedeployments: make([]*MachineDeployment, 0),
+		machinedeployments: make(map[types.NamespacedName]*MachineDeployment),
 		resourceLimiter:    resourceLimiter,
 	}
 	for _, spec := range specs {
@@ -109,7 +110,8 @@ func (mcm *mcmCloudProvider) addNodeGroup(spec string) error {
 }
 
 func (mcm *mcmCloudProvider) addMachineDeployment(machinedeployment *MachineDeployment) {
-	mcm.machinedeployments = append(mcm.machinedeployments, machinedeployment)
+	key := types.NamespacedName{Namespace: machinedeployment.Namespace, Name: machinedeployment.Name}
+	mcm.machinedeployments[key] = machinedeployment
 	return
 }
 
@@ -151,13 +153,8 @@ func (mcm *mcmCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 		return nil, err
 	}
 
-	var isManaged bool
-	for _, managedMachineDeployment := range mcm.machinedeployments {
-		if managedMachineDeployment.Id() == md.Id() {
-			isManaged = true
-			break
-		}
-	}
+	key := types.NamespacedName{Namespace: md.Namespace, Name: md.Name}
+	_, isManaged := mcm.machinedeployments[key]
 	if !isManaged {
 		klog.V(4).Infof("Skipped node %v, it's not managed by this controller", node.Spec.ProviderID)
 		return nil, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently the mcm cloudprovider is returning the unmanaged
MachineDeployment when an unmanaged node is given to NodeGroupForNode.

It should return a nil NodeGroup instead if the autoscaler isn't
managing the MachineDeployment.

Currently this leads to this kind of error filling the logs:

```
E0520 13:42:55.997915       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-a: group size not found
E0520 13:42:55.998015       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-a: group size not found
E0520 13:42:55.998172       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-a: group size not found
E0520 13:42:55.998237       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-b: group size not found
E0520 13:42:55.998322       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-b: group size not found
E0520 13:42:55.998360       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-a: group size not found
E0520 13:42:55.998402       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-c: group size not found
E0520 13:42:55.998468       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-c: group size not found
E0520 13:42:55.998583       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-c: group size not found
E0520 13:42:55.998623       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-b: group size not found
E0520 13:42:55.998820       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-a: group size not found
E0520 13:42:55.998866       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-c: group size not found
E0520 13:42:55.998958       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-b: group size not found
E0520 13:42:55.999123       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-c: group size not found
E0520 13:42:55.999150       1 pre_filtering_processor.go:62] Error while checking node group size mcm-immutable-node-az-b: group size not found
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Do not return errors while fetching details for an unmanaged node.
```


