### PR TITLE
[rel-0.10] Avoids panics when VM type isn't found during scale from zero

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -421,7 +421,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 		if err != nil {
 			return nil, fmt.Errorf("Unable to fetch AWSMachineClass object %s, Error: %v", machinedeployment.Name, err)
 		}
-		awsInstance := aws.InstanceTypes[mc.Spec.MachineType]
+		awsInstance, exists := aws.InstanceTypes[mc.Spec.MachineType]
+		if !exists {
+			return nil, fmt.Errorf("Unable to fetch details for VM type %s", mc.Spec.MachineType)
+		}
 		instance = instanceType{
 			InstanceType: awsInstance.InstanceType,
 			VCPU:         awsInstance.VCPU,
@@ -437,7 +440,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 		if err != nil {
 			return nil, fmt.Errorf("Unable to fetch AzureMachineClass object %s, Error: %v", machinedeployment.Name, err)
 		}
-		azureInstance := azure.InstanceTypes[mc.Spec.Properties.HardwareProfile.VMSize]
+		azureInstance, exists := azure.InstanceTypes[mc.Spec.Properties.HardwareProfile.VMSize]
+		if !exists {
+			return nil, fmt.Errorf("Unable to fetch details for VM type %s", mc.Spec.Properties.HardwareProfile.VMSize)
+		}
 		instance = instanceType{
 			InstanceType: azureInstance.InstanceType,
 			VCPU:         azureInstance.VCPU,
@@ -462,7 +468,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 				return nil, fmt.Errorf("Unable to convert from %s to %s for %s, Error: %v", kindMachineClass, providerAWS, machinedeployment.Name, err)
 			}
 
-			awsInstance := aws.InstanceTypes[providerSpec.MachineType]
+			awsInstance, exists := aws.InstanceTypes[providerSpec.MachineType]
+			if !exists {
+				return nil, fmt.Errorf("Unable to fetch details for VM type %s", providerSpec.MachineType)
+			}
 			instance = instanceType{
 				InstanceType: awsInstance.InstanceType,
 				VCPU:         awsInstance.VCPU,
@@ -479,8 +488,10 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *Machine
 			if err != nil {
 				return nil, fmt.Errorf("Unable to convert from %s to %s for %s, Error: %v", kindMachineClass, providerAzure, machinedeployment.Name, err)
 			}
-
-			azureInstance := aws.InstanceTypes[providerSpec.Properties.HardwareProfile.VMSize]
+			azureInstance, exists := azure.InstanceTypes[providerSpec.Properties.HardwareProfile.VMSize]
+			if !exists {
+				return nil, fmt.Errorf("Unable to fetch details for VM type %s", providerSpec.Properties.HardwareProfile.VMSize)
+			}
 			instance = instanceType{
 				InstanceType: azureInstance.InstanceType,
 				VCPU:         azureInstance.VCPU,


### PR DESCRIPTION
/kind bug
/kind regression

Cherry pick of #77 on rel-0.10.

#77: Avoids panics when VM type isn't found during scale from zero

Fixes https://github.com/gardener/autoscaler/issues/76

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```bugfix user
Avoids panics when VM type isn't found during scale from zero
```

```bugfix user
Fetches the VM from the correct map for MCM provider Azure and hence doesn't panic anymore
```