### PR TITLE
Adding VPA modifications tests for the issue #93 in autoscaler

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -316,6 +316,11 @@ func (cluster *ClusterState) MakeAggregateStateKey(pod *PodState, containerName 
 	}
 }
 
+// GetAggregateStateMap returns the current aggregateStateMap in cluster state object
+func (cluster *ClusterState) GetAggregateStateMap() aggregateContainerStatesMap {
+	return cluster.aggregateStateMap
+}
+
 // aggregateStateKeyForContainerID returns the AggregateStateKey for the ContainerID.
 // The pod with the corresponding PodID must already be present in the ClusterState.
 func (cluster *ClusterState) aggregateStateKeyForContainerID(containerID ContainerID) AggregateStateKey {

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -194,3 +194,14 @@ func TestRecordOOMInNewWindow(t *testing.T) {
 	test.mockMemoryHistogram.On("AddSample", 2400.0*mb, 1.0, memoryAggregationWindowEnd)
 	assert.NoError(t, test.container.RecordOOM(testTimestamp.Add(2*memoryAggregationInterval), ResourceAmount(1000*mb)))
 }
+
+func TestRecordOOMSampleAndCountTotalSamples(t *testing.T) {
+	test := newContainerTest()
+	memoryAggregationWindowEnd := testTimestamp.Add(GetAggregationsConfig().MemoryAggregationInterval)
+	// Increase the memory by 20%
+	test.mockMemoryHistogram.On("AddSample", 1200.0*mb, 1.0, memoryAggregationWindowEnd)
+	assert.NoError(t, test.container.RecordOOM(testTimestamp, ResourceAmount(1000*mb)))
+
+	// Check if TotalSamplesCount is calculated for memory sample addition
+	assert.Equal(t, 1, test.aggregateContainerState.TotalSamplesCount)
+}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/recommender_routines_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/recommender_routines_test.go
@@ -1,0 +1,267 @@
+package routines
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	"k8s.io/klog"
+)
+
+// getOOMParam defines a function return type to handle tests
+// for both OOMBumpUpRatio and OOMMinBUmp
+type getOOMParam func(float64) float64
+
+var (
+	testPodID1       = model.PodID{Namespace: "namespace-1", PodName: "pod-1"}
+	testLabels       = map[string]string{"label-1": "value-1"}
+	timeLayout       = "2006-01-02 15:04:05"
+	testTimestamp, _ = time.Parse(timeLayout, "2021-08-11 14:53:05")
+	testRequest      = model.Resources{
+		model.ResourceCPU:    model.CPUAmountFromCores(0.5),
+		model.ResourceMemory: model.MemoryAmountFromBytes(100),
+	}
+	testLimit = model.Resources{ // Setting limits to 3x of testRequest
+		model.ResourceCPU:    model.CPUAmountFromCores(1.0),
+		model.ResourceMemory: model.MemoryAmountFromBytes(300),
+	}
+	testUpdateModeAuto = vpa_types.UpdateModeAuto
+	testSelectorStr    = "label-1 = value-1"
+	testVpaID          = model.VpaID{
+		Namespace: testPodID1.Namespace,
+		VpaName:   "testVPA",
+	}
+)
+
+func addTestMemorySample(cluster *model.ClusterState, container model.ContainerID, memoryBytes float64, timeStamp time.Time) error {
+	sample := model.ContainerUsageSampleWithKey{
+		Container: container,
+		ContainerUsageSample: model.ContainerUsageSample{
+			MeasureStart: timeStamp,
+			Usage:        model.MemoryAmountFromBytes(memoryBytes),
+			Request:      testRequest[model.ResourceMemory],
+			Resource:     model.ResourceMemory,
+		},
+	}
+	return cluster.AddSample(&sample)
+}
+
+func addTestCPUHistogram(samples []float64, weight float64, testTimeStamp time.Time, options util.HistogramOptions) util.Histogram {
+	cpuHistogram := util.NewHistogram(options)
+	for _, sample := range samples {
+		cpuHistogram.AddSample(sample, weight, testTimestamp)
+	}
+
+	return cpuHistogram
+}
+
+func addTestMemoryHistogram(samples []float64, weight float64, timeStamp time.Time, options util.HistogramOptions) util.Histogram {
+	memoryHistogram := util.NewHistogram(options)
+	for _, sample := range samples {
+		memoryHistogram.AddSample(sample, weight, testTimestamp)
+	}
+
+	return memoryHistogram
+}
+
+func surgeSampleBasedMemoryEstimation(memorySample float64, maxAllowedMemory float64,
+	cpuHistogram util.Histogram, memoryPeaksHistogram util.Histogram,
+	cpuPercentile float64, memPercentile float64, fn getOOMParam) (model.Resources, int) {
+	surgeSamplesCount := 1
+	var resourceEstimation model.Resources
+	for {
+		if memorySample < maxAllowedMemory {
+			memorySample = fn(memorySample)
+		}
+		memoryPeaksHistogram.AddSample(memorySample, 1.0, testTimestamp)
+		resourceEstimation = GetPercentileResourceEstimation(cpuPercentile, memPercentile,
+			cpuHistogram, memoryPeaksHistogram)
+
+		if resourceEstimation[model.ResourceMemory] >= model.ResourceAmount(memorySample) {
+			break
+		}
+		surgeSamplesCount++
+	}
+
+	return resourceEstimation, surgeSamplesCount
+}
+
+func GetPercentileResourceEstimation(cpuPercentile float64, memPercentile float64,
+	cpuHistogram util.Histogram, memoryHistogram util.Histogram) model.Resources {
+
+	estimator := logic.NewPercentileEstimator(cpuPercentile, memPercentile)
+
+	return estimator.GetResourceEstimation(
+		&model.AggregateContainerState{
+			AggregateCPUUsage:    cpuHistogram,
+			AggregateMemoryPeaks: memoryHistogram,
+		})
+}
+
+func getTestVPAObj(cluster *model.ClusterState, container model.ContainerID) *model.Vpa {
+	vpa := test.VerticalPodAutoscaler().WithName(testVpaID.VpaName).
+		WithNamespace(testVpaID.Namespace).WithContainer(container.ContainerName).WithUpdateMode(testUpdateModeAuto).Get()
+
+	labelSelector, _ := metav1.ParseToLabelSelector(testSelectorStr)
+	parsedSelector, _ := metav1.LabelSelectorAsSelector(labelSelector)
+	err := cluster.AddOrUpdateVpa(vpa, parsedSelector)
+	if err != nil {
+		klog.Fatalf("AddOrUpdateVpa() failed: %v", err)
+	}
+
+	return cluster.Vpas[testVpaID]
+}
+
+// Verifies that recommendation does not occur and remains Nil
+// if only memory samples are added onto the aggregate container state
+// histogram. The variable TotalSamplesCount is counted only for CPU
+// samples and a similar for memory should be introduced.
+func TestRecommendationForZeroTotalSamplesCount(t *testing.T) {
+	cluster := model.NewClusterState()
+	cluster.AddOrUpdatePod(testPodID1, testLabels, apiv1.PodRunning)
+	container := model.ContainerID{PodID: testPodID1, ContainerName: "app-A"}
+
+	assert.NoError(t, cluster.AddOrUpdateContainer(container, testRequest))
+	assert.NoError(t, addTestMemorySample(cluster, container, 2e9, testTimestamp))
+
+	pod := cluster.Pods[testPodID1]
+	aggregateStateKey := cluster.MakeAggregateStateKey(pod, "app-A")
+	aggregateResources := cluster.GetAggregateStateMap()
+	// Note: This returns TotalSamplesCount as 0 as we are only adding memory sample
+	// This is handled in another test case (TestTotalSamplesCountMemorySamplesOnly).
+	// Ignorning and continuing to seek recommendations for now. Fix it to equal to 1.
+	assert.Equal(t, 0, aggregateResources[aggregateStateKey].TotalSamplesCount)
+
+	recommender := logic.CreatePodResourceRecommender()
+	vpaObj := getTestVPAObj(cluster, container)
+	recommendedResources := recommender.GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpaObj))
+	assert.NotEmpty(t, recommendedResources)
+
+}
+
+// Verifies the number of samples it takes for the current
+// VPA recommender estimation to beat the current surge in usage.
+// The surge is determined and samples w.r.t that is added using
+// model.OOMBumpUpRatio
+func TestAddMemorySurgeWithOOMBumpUpRatio(t *testing.T) {
+	config := model.GetAggregationsConfig()
+	maxAllowedMemory := 5e10
+	cpuSamples := []float64{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}
+	cpuHistogram := addTestCPUHistogram(cpuSamples, 1.0, testTimestamp, config.CPUHistogramOptions)
+
+	var memSamples []float64
+	for i := 0; i < 20; i++ {
+		memSamples = append(memSamples, 1e6)
+	}
+	memoryPeaksHistogram := addTestMemoryHistogram(memSamples, 1.0, testTimestamp, config.MemoryHistogramOptions)
+
+	ResourcePercentile := 0.9 // Same as in podResourceRecommender for target estimator
+	resourceEstimation := GetPercentileResourceEstimation(ResourcePercentile, ResourcePercentile,
+		cpuHistogram, memoryPeaksHistogram)
+	maxRelativeError := 0.05 // Allow 5% relative error to account for histogram rounding.
+	assert.InEpsilon(t, 1e7, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+
+	// Adding sudden surge sample to memory histogram
+	memoryPeaksHistogram.AddSample(4e10, 1.0, testTimestamp)
+	resourceEstimation = GetPercentileResourceEstimation(ResourcePercentile, ResourcePercentile,
+		cpuHistogram, memoryPeaksHistogram)
+
+	// still recommends 1e6 value as memory recommendation.
+	// Note: VPA recommender doesn't immediately respond to
+	// surge of memory resource
+	assert.InEpsilon(t, 1e7, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+
+	surgeSample := 4e10
+	// add a closure to increase memorySample by 1.2 times as defined in model.OOMBumpUpRatio
+	getOOMBumpUpRatio := func(memorySample float64) float64 { return memorySample * model.OOMBumpUpRatio }
+	resourceEstimation, surgeSamplesCount := surgeSampleBasedMemoryEstimation(surgeSample, maxAllowedMemory,
+		cpuHistogram, memoryPeaksHistogram, ResourcePercentile, ResourcePercentile, getOOMBumpUpRatio)
+
+	assert.InEpsilon(t, 60080658359, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+	assert.Greater(t, 3, surgeSamplesCount) // Fail if greater than 3 surge samples collected
+
+}
+
+// Verifies the number of samples it takes for the current
+// VPA recommender estimation to beat the current surge in usage.
+// The surge is determined and samples w.r.t that is added using
+// model.OOMMinBumpUp
+func TestAddMemorySurgeWithOOMMinBump(t *testing.T) {
+	config := model.GetAggregationsConfig()
+	maxAllowedMemory := 5e10
+	cpuSamples := []float64{1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0}
+	cpuHistogram := addTestCPUHistogram(cpuSamples, 1.0, testTimestamp, config.CPUHistogramOptions)
+
+	var memSamples []float64
+	for i := 0; i < 40; i++ {
+		memSamples = append(memSamples, 1e6)
+	}
+	memoryPeaksHistogram := addTestMemoryHistogram(memSamples, 1.0, testTimestamp, config.MemoryHistogramOptions)
+
+	ResourcePercentile := 0.9 // Same as in podResourceRecommender for target estimator
+	resourceEstimation := GetPercentileResourceEstimation(ResourcePercentile, ResourcePercentile,
+		cpuHistogram, memoryPeaksHistogram)
+	maxRelativeError := 0.05 // Allow 5% relative error to account for histogram rounding.
+	assert.InEpsilon(t, 1e7, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+
+	// Adding sudden surge sample to memory histogram
+	memoryPeaksHistogram.AddSample(4e10, 1.0, testTimestamp)
+	resourceEstimation = GetPercentileResourceEstimation(ResourcePercentile, ResourcePercentile,
+		cpuHistogram, memoryPeaksHistogram)
+
+	// still recommends 1e6 value as memory recommendation.
+	// Note: VPA recommender doesn't immediately respond to
+	// surge of memory resource
+	assert.InEpsilon(t, 1e7, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+
+	surgeSample := 4e10
+	// add a closure to increase memorySample by 100MB as defined in model.OOMMinBumUp
+	getOOMBumpUpRatio := func(memorySample float64) float64 { return memorySample + model.OOMMinBumpUp }
+	resourceEstimation, surgeSamplesCount := surgeSampleBasedMemoryEstimation(surgeSample, maxAllowedMemory,
+		cpuHistogram, memoryPeaksHistogram, ResourcePercentile, ResourcePercentile, getOOMBumpUpRatio)
+
+	assert.InEpsilon(t, 40600322346, model.BytesFromMemoryAmount(resourceEstimation[model.ResourceMemory]), maxRelativeError)
+	assert.Greater(t, 3, surgeSamplesCount) // Fail if greater than 3 surge samples collected
+
+}
+
+// Showcases the need of containerState.RecordOOM like function for
+// recording CPU throttle information which should be added to CPU
+// histogram if the CPU usage is constantly above current pod limits set.
+// CPU throttle information recorded should later be bumping the CPU sample
+// similar to containerState.RecordOOM to ensure higher recommendation is
+// provided for preventing CPU starvation
+func TestRecordCPUThrottlingInformation(t *testing.T) {
+	config := model.GetAggregationsConfig()
+	// include CPU samples greater than current limits to showcase throttle
+	cpuSamples := []float64{0.9, 0.95, 1.0, 1.2, 1.3, 1.4, 1.5, 1.6, 1.8, 1.9}
+	cpuHistogram := addTestCPUHistogram(cpuSamples, 1.0, testTimestamp, config.CPUHistogramOptions)
+
+	var memSamples []float64
+	for i := 0; i < 20; i++ {
+		memSamples = append(memSamples, 1e6)
+	}
+	memoryPeaksHistogram := addTestMemoryHistogram(memSamples, 1.0, testTimestamp, config.MemoryHistogramOptions)
+
+	ResourcePercentile := 0.9 // Same as in podResourceRecommender for target estimator
+	resourceEstimation := GetPercentileResourceEstimation(ResourcePercentile, ResourcePercentile,
+		cpuHistogram, memoryPeaksHistogram)
+
+	resourceRecommendation := model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU])
+	cpuRequestsToLimitsRatio := float64(testLimit[model.ResourceCPU] / testRequest[model.ResourceCPU])
+	newCPULimitBasedOnRecommendation := cpuRequestsToLimitsRatio * float64(testLimit[model.ResourceCPU])
+	// calculate 90% of post recommendation CPU limits value
+	cpuThrottleLimit := 0.9 * model.CoresFromCPUAmount(model.ResourceAmount(newCPULimitBasedOnRecommendation))
+
+	// assert if the current CPU recommendation >= 90% of CPU Limits post recommendation
+	// This should hence show a requirement of RecordCPUThrottle like containerState.RecordOOM
+	// which bumps the CPU sample by some value before adding it to the histogram
+	assert.LessOrEqual(t, resourceRecommendation, cpuThrottleLimit)
+}

--- a/vertical-pod-autoscaler/pkg/recommender/routines/vpa_routines_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/routines/vpa_routines_test.go
@@ -1,0 +1,68 @@
+package routines
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/test"
+	"k8s.io/klog"
+)
+
+func addTestMemorySample(cluster *model.ClusterState, container model.ContainerID, memoryBytes float64, timeStamp time.Time) error {
+	sample := model.ContainerUsageSampleWithKey{
+		Container: container,
+		ContainerUsageSample: model.ContainerUsageSample{
+			MeasureStart: timeStamp,
+			Usage:        model.MemoryAmountFromBytes(memoryBytes),
+			Request:      recommenderTestRequest[model.ResourceMemory],
+			Resource:     model.ResourceMemory,
+		},
+	}
+	return cluster.AddSample(&sample)
+}
+
+func getTestVPAObj(cluster *model.ClusterState, container model.ContainerID) *model.Vpa {
+	vpa := test.VerticalPodAutoscaler().WithName(testVpaID.VpaName).
+		WithNamespace(testVpaID.Namespace).WithContainer(container.ContainerName).WithUpdateMode(testUpdateModeAuto).Get()
+
+	labelSelector, _ := metav1.ParseToLabelSelector(testSelectorStr)
+	parsedSelector, _ := metav1.LabelSelectorAsSelector(labelSelector)
+	err := cluster.AddOrUpdateVpa(vpa, parsedSelector)
+	if err != nil {
+		klog.Fatalf("AddOrUpdateVpa() failed: %v", err)
+	}
+
+	return cluster.Vpas[testVpaID]
+}
+
+// Verifies that recommendation does not occur and remains Nil
+// if only memory samples are added onto the aggregate container state
+// histogram. The variable TotalSamplesCount is counted only for CPU
+// samples and a similar for memory should be introduced.
+func TestRecommendationForZeroTotalSamplesCount(t *testing.T) {
+	cluster := model.NewClusterState()
+	cluster.AddOrUpdatePod(testPodID1, testLabels, apiv1.PodRunning)
+	container := model.ContainerID{PodID: testPodID1, ContainerName: "app-A"}
+
+	assert.NoError(t, cluster.AddOrUpdateContainer(container, recommenderTestRequest))
+	assert.NoError(t, addTestMemorySample(cluster, container, 2e9, testTimestamp))
+
+	pod := cluster.Pods[testPodID1]
+	aggregateStateKey := cluster.MakeAggregateStateKey(pod, "app-A")
+	aggregateResources := cluster.GetAggregateStateMap()
+	// Note: This returns TotalSamplesCount as 0 as we are only adding memory sample
+	// This is handled in another test case (TestTotalSamplesCountMemorySamplesOnly).
+	// Ignorning and continuing to seek recommendations for now. Fix it to equal to 1.
+	assert.Equal(t, 0, aggregateResources[aggregateStateKey].TotalSamplesCount)
+
+	recommender := logic.CreatePodResourceRecommender()
+	vpaObj := getTestVPAObj(cluster, container)
+	recommendedResources := recommender.GetRecommendedPodResources(GetContainerNameToAggregateStateMap(vpaObj))
+	assert.NotEmpty(t, recommendedResources)
+
+}


### PR DESCRIPTION
Tests:
TestTotalSamplesCountMemorySamplesOnly
    - Issue with covering TotalSamplesCount adding only CPU samples and with memory samples not being counted.
TestRecordOOMSampleAndCountTotalSamples
    - Issue with recording OOM Samples but still TotalSamplesCount not being updated in aggregate container state.
TestRecommendationForZeroTotalSamplesCount
    - Issue with not getting any recommendation if the CPU samples are not added and there by TotalSamplesCount is 0.
TestAddMemorySurgeWithOOMBumpUpRatio
    - Hardcoded OOMBumpUpRatio (=1.2) and hence takes more time to recover with more number of restarts. Can be made user defined.
TestAddMemorySurgeWithOOMMinBump
    - Hardcoded OOMMinBump (=100MB) and hence takes more time to recover with more number of restarts. Can be made user defined.
TestRecordCPUThrottlingInformation
    - Showcases the need of containerState.RecordOOM like function for recording CPU throttle information which should be added to CPU histogram if the CPU usage is constantly above current pod limits set
TestRecommenderScaleUp
    - Normal scale up behavior of the existing VPA recommender
TestRecommenderScaleDown
    - Normal scale down behavior of the existing VPA recommender

The above test cases currently fail indicating the problem
with to be fixed as mentioned in #93. They validate the
change required in the behavior for VPA recommendation.

**What this PR does / why we need it**:
The above set of UT validates the issues in #93 
We need to fix the existing VPA recommender code to make
sure we have proper behavior which is blocking us at specific places.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator

```