### PR TITLE
Added more Integration Tests and automation for running Integration Tests locally

### DIFF
--- a/cluster-autoscaler/.gitignore
+++ b/cluster-autoscaler/.gitignore
@@ -12,3 +12,4 @@ main
 Session.vim
 .netrwhist
 .vscode
+/integration/logs

--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -128,6 +128,32 @@ start:
 			--leader-elect-renew-deadline="30s" \
 			--leader-elect-lease-duration="40s"
 
+
+.PHONY: download-kubeconfigs
+download-kubeconfigs:
+	@chmod +x ./hack/local_setup.sh
+	@echo "enter project name"; \
+	read PROJECT; \
+	echo "enter seed name"; \
+	read SEED; \
+	echo "enter shoot name"; \
+	read SHOOT; \
+	echo "enter cluster provider(gcp|aws|azure|vsphere|openstack|alicloud|metal|equinix-metal)"; \
+	read PROVIDER; \
+	echo "enter zone with zero nodes where the PV needs to be created to perform test"; \
+	read ZONE; \
+	. ./hack/local_setup.sh --SEED $$SEED --SHOOT $$SHOOT --PROJECT $$PROJECT; \
+	echo "###############################################" ; \
+	echo "To run the integration test run the following commands"; \
+	echo " ";\
+	echo "export CONTROL_NAMESPACE=$$CONTROL_NAMESPACE"; \
+	echo "export CONTROL_KUBECONFIG=$$CONTROL_KUBECONFIG"; \
+	echo "export TARGET_KUBECONFIG=$$TARGET_KUBECONFIG"; \
+	echo "export CLUSTER_PROVIDER=$$PROVIDER"; \
+	echo "export VOLUME_ZONE=$$ZONE"; \
+	echo " "; \
+	echo "make test-integration"
+
 .PHONY: test-integration
 test-integration:
 	../.ci/local_integration_test

--- a/cluster-autoscaler/hack/local_setup.sh
+++ b/cluster-autoscaler/hack/local_setup.sh
@@ -1,0 +1,68 @@
+# /*
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+
+
+#HOW TO CALL 
+#```````````````````````````````````````````````````````````````````````````````````````````
+
+# ./local_setup.sh --PROJECT <project-name> --SEED <seed-name> --SHOOT <shoot-name>
+
+#```````````````````````````````````````````````````````````````````````````````````````````
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+while [ $# -gt 0 ]; do
+
+   if [[ $1 == *"--"* ]]; then
+        v="${1/--/}"
+        declare $v="$2"
+   fi
+
+  shift
+done
+
+CURRENT_DIR=$(pwd)
+PROJECT_ROOT="${CURRENT_DIR}"
+KUBECONFIG_PATH=$PROJECT_ROOT/dev/kubeconfigs
+
+#setting kuebconfig of control cluster
+
+gardenctl target --garden sap-landscape-dev --project garden
+
+eval $(gardenctl kubectl-env bash)
+
+echo "$(kubectl get secret/$SEED.kubeconfig --template={{.data.kubeconfig}} | base64 -d)" > $KUBECONFIG_PATH/kubeconfig_control.yaml
+
+#setting up the target config
+
+gardenctl target --garden sap-landscape-dev --project $PROJECT --shoot $SHOOT --control-plane
+
+eval $(gardenctl kubectl-env bash)
+
+SECRET=$(kubectl get secrets | awk '{ print $1 }' |grep user-kubeconfig-)
+
+echo "$(kubectl get secret/$SECRET -n shoot--$PROJECT--$SHOOT --template={{.data.kubeconfig}} | base64 -d)" > $KUBECONFIG_PATH/kubeconfig_target.yaml
+
+# All the kubeconfigs are at place
+
+echo "kubeconfigs have been downloaded and kept at /dev/kubeconfigs/kubeconfig_<target/control>.yaml"
+
+export CONTROL_NAMESPACE=shoot--$PROJECT--$SHOOT
+export CONTROL_KUBECONFIG=$KUBECONFIG_PATH/kubeconfig_control.yaml
+export TARGET_KUBECONFIG=$KUBECONFIG_PATH/kubeconfig_target.yaml

--- a/cluster-autoscaler/integration/framework.go
+++ b/cluster-autoscaler/integration/framework.go
@@ -5,17 +5,37 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
-	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-
 	appv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	v1storage "k8s.io/api/storage/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/pointer"
+)
+
+const (
+	//annotaion which makes dwd skip the scaling of component
+	dwdAnnotation string = "dependency-watchdog.gardener.cloud/ignore-scaling"
+	//annotaion to skip the scaling down of exrta/unused node.
+	ignoreScaledownAnnotation string = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+)
+
+var (
+	criticalAddonsOnlyTaint = "CriticalAddonsOnly"
+	disabledTaint           = "DisabledForAutoscalingTest"
+	smallMemory             = "50Mi"
+	mediumMemory            = "150Mi"
+	largeMemory             = "500Mi"
+	smallCPU                = "500m"
+	cpuResource             int64
 )
 
 // rotateLogFile takes file name as input and returns a file object obtained by os.Create
@@ -57,12 +77,12 @@ func (driver *Driver) adjustNodeGroups() error {
 		}
 	}
 
-	ginkgo.By("Adjusting node groups to initial required size")
-	gomega.Eventually(
+	By("Adjusting node groups to initial required size")
+	Eventually(
 		driver.targetCluster.getNumberOfReadyNodes,
 		pollingTimeout,
 		pollingInterval).
-		Should(gomega.BeNumerically("==", initialNumberOfNodes))
+		Should(BeNumerically("==", initialNumberOfNodes))
 
 	return nil
 }
@@ -72,6 +92,7 @@ func (c *Cluster) getNumberOfReadyNodes() int16 {
 	nodes, _ := c.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	count := 0
 	for _, n := range nodes.Items {
+		cpuResource, _ = (n.Status.Capacity.Cpu()).AsInt64()
 		for _, nodeCondition := range n.Status.Conditions {
 			if nodeCondition.Type == "Ready" && nodeCondition.Status == "True" {
 				count++
@@ -82,7 +103,7 @@ func (c *Cluster) getNumberOfReadyNodes() int16 {
 }
 
 func (driver *Driver) scaleAutoscaler(replicas int32) error {
-	autoScalerDeployment, err := driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Get(context.Background(), "cluster-autoscaler", metav1.GetOptions{})
+	autoscalerDeployment, err := driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Get(context.Background(), "cluster-autoscaler", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -90,11 +111,15 @@ func (driver *Driver) scaleAutoscaler(replicas int32) error {
 	if replicas > 1 {
 		replicas = 1
 	}
-
-	if autoScalerDeployment.Spec.Replicas != pointer.Int32Ptr(replicas) {
-		autoScalerDeployment.Spec.Replicas = pointer.Int32Ptr(replicas)
+	if replicas == 0 {
+		autoscalerDeployment.ObjectMeta.Annotations[dwdAnnotation] = "true"
+	} else if replicas == 1 {
+		delete(autoscalerDeployment.ObjectMeta.Annotations, dwdAnnotation)
+	}
+	if autoscalerDeployment.Spec.Replicas != pointer.Int32Ptr(replicas) {
+		autoscalerDeployment.Spec.Replicas = pointer.Int32Ptr(replicas)
 		fmt.Printf("Scaling Cluster Autoscaler to %d replicas\n", replicas)
-		_, err = driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Update(context.Background(), autoScalerDeployment, metav1.UpdateOptions{})
+		_, err = driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Update(context.Background(), autoscalerDeployment, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
@@ -118,7 +143,7 @@ func (driver *Driver) runAutoscaler() {
 		return
 	}
 
-	ginkgo.By("Starting Cluster Autoscaler....")
+	By("Starting Cluster Autoscaler....")
 	args := strings.Fields(
 		fmt.Sprintf(
 			"make --directory=%s start TARGET_KUBECONFIG=%s MACHINE_DEPLOYMENT_ZONE_1=%s MACHINE_DEPLOYMENT_ZONE_2=%s MACHINE_DEPLOYMENT_ZONE_3=%s LEADER_ELECT=%s",
@@ -132,16 +157,135 @@ func (driver *Driver) runAutoscaler() {
 	)
 
 	outputFile, err := rotateLogFile(CALogFile)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+	Expect(err).ShouldNot(HaveOccurred())
 	autoscalerSession, err = gexec.Start(exec.Command(args[0], args[1:]...), outputFile, outputFile)
-	gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-	gomega.Expect(autoscalerSession.ExitCode()).Should(gomega.Equal(-1))
+	Expect(err).ShouldNot(HaveOccurred())
+	Expect(autoscalerSession.ExitCode()).Should(Equal(-1))
 }
 
-func getDeploymentObject(replicas int32) *appv1.Deployment {
+func getStorageClassObject(class string) (*v1storage.StorageClass, error) {
+	provider := os.Getenv("CLUSTER_PROVIDER")
+	var provisioner string
+	switch provider {
+	case "aws":
+		provisioner = "ebs.csi.aws.com"
+	case "azure":
+		provisioner = "disk.csi.azure.com"
+	case "gcp":
+		provisioner = "pd.csi.storage.gke.io"
+	default:
+		return nil, fmt.Errorf("invalid cluster provider")
+	}
+	allowExpansion := true
+	volumeReclaimPolicy := v1.PersistentVolumeReclaimDelete
+	volumeBindingMode := v1storage.VolumeBindingImmediate
+	var zone []string = []string{os.Getenv("VOLUME_ZONE")}
+	var expressions []v1.TopologySelectorLabelRequirement = []v1.TopologySelectorLabelRequirement{{Key: "topology.kubernetes.io/zone", Values: zone}}
+	// for GKE
+	// var expressions []v1.TopologySelectorLabelRequirement = []v1.TopologySelectorLabelRequirement{{Key: "topology.gke.io/zone", Values: zone}}
+	var topologies []v1.TopologySelectorTerm = []v1.TopologySelectorTerm{{MatchLabelExpressions: expressions}}
+
+	storageClass := &v1storage.StorageClass{
+		AllowVolumeExpansion: &allowExpansion,
+		ObjectMeta: metav1.ObjectMeta{
+			Name: class,
+			Labels: map[string]string{
+				"shoot.gardener.cloud/no-cleanup": "true",
+			},
+			Annotations: map[string]string{
+				"resources.gardener.cloud/delete-on-invalid-update": "true",
+			},
+		},
+		Provisioner:       provisioner,
+		ReclaimPolicy:     &volumeReclaimPolicy,
+		VolumeBindingMode: &volumeBindingMode,
+		AllowedTopologies: topologies,
+	}
+	return storageClass, nil
+}
+
+func getPvcObject(claimName string, class string) *v1.PersistentVolumeClaim {
+	namespace := "default"
+	cap := "2Gi"
+	var mode []v1.PersistentVolumeAccessMode
+	pvc := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      claimName,
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			Resources:        v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceName(v1.ResourceStorage): resource.MustParse(cap)}},
+			AccessModes:      append(mode, v1.ReadWriteOnce),
+			StorageClassName: &class,
+		},
+	}
+	return pvc
+}
+
+func getDeploymentObjectWithVolumeReq(deploymentName string, claimName string) *appv1.Deployment {
 	deployment := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      scaleUpWorkload,
+			Name:      deploymentName,
+			Namespace: "default",
+		},
+		Spec: appv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "nginx",
+				},
+			},
+			Replicas: pointer.Int32Ptr(1),
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "nginx",
+					},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "ngnix-container",
+							Image: "nginx:latest",
+							Ports: []v1.ContainerPort{
+								{
+									ContainerPort: 80,
+								},
+							},
+							Resources: v1.ResourceRequirements{
+								Requests: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1"),
+									v1.ResourceMemory: resource.MustParse("50Mi"),
+								},
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									MountPath: "/var/www/html",
+									Name:      "mypd",
+								},
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "mypd",
+							VolumeSource: v1.VolumeSource{
+								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+									ClaimName: claimName,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	return deployment
+}
+
+func getDeploymentObject(replicas int32, resourceCpu string, resourceMemory string, workloadName string) *appv1.Deployment {
+	deployment := &appv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      workloadName,
 			Namespace: "default",
 		},
 		Spec: appv1.DeploymentSpec{
@@ -167,11 +311,10 @@ func getDeploymentObject(replicas int32) *appv1.Deployment {
 									ContainerPort: 80,
 								},
 							},
-							// TODO: this is the object to be dynamically changed based on the machine type
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse("3"),
-									v1.ResourceMemory: resource.MustParse("150Mi"),
+									v1.ResourceCPU:    resource.MustParse(resourceCpu),
+									v1.ResourceMemory: resource.MustParse(resourceMemory),
 								},
 							},
 						},
@@ -183,8 +326,26 @@ func getDeploymentObject(replicas int32) *appv1.Deployment {
 	return deployment
 }
 
-func (driver *Driver) deployWorkload(replicas int32) error {
-	deployment := getDeploymentObject(replicas)
+func (driver *Driver) deployWorkload(replicas int32, workloadName string) error {
+	deployment := getDeploymentObject(replicas, fmt.Sprint(cpuResource-1), mediumMemory, workloadName)
+	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) deployLargeWorkload(replicas int32, workloadName string) error {
+	deployment := getDeploymentObject(replicas, fmt.Sprint(cpuResource+1), largeMemory, "large-"+workloadName)
+	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) deploySmallWorkload(replicas int32, workloadName string) error {
+	deployment := getDeploymentObject(replicas, smallCPU, smallMemory, "small-"+workloadName)
 	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -205,4 +366,112 @@ func (driver *Driver) scaleWorkload(workloadName string, replicas int32) error {
 		return err
 	}
 	return nil
+}
+
+func (driver *Driver) getOldestAndLatestNode() (*v1.Node, *v1.Node, error) {
+	nodeList, err := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(nodeList.Items) < 1 {
+		err = fmt.Errorf("no nodes found")
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	//sorting in ascending order of creation timeStamp
+	sort.Slice(nodeList.Items, func(i, j int) bool {
+		return nodeList.Items[i].ObjectMeta.CreationTimestamp.Before(&nodeList.Items[j].ObjectMeta.CreationTimestamp)
+	})
+	oldestNode := nodeList.Items[0]
+	latestNode := nodeList.Items[len(nodeList.Items)-1]
+	return &oldestNode, &latestNode, nil
+}
+
+func (driver *Driver) addAnnotationToNode(node *v1.Node) error {
+	node.ObjectMeta.Annotations[ignoreScaledownAnnotation] = "true"
+	_, err := driver.targetCluster.Clientset.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) removeAnnotationFromNode(node *v1.Node) error {
+	delete(node.ObjectMeta.Annotations, ignoreScaledownAnnotation)
+	_, err := driver.targetCluster.Clientset.CoreV1().Nodes().Update(context.Background(), node, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (driver *Driver) makeNodeUnschedulable(node *v1.Node) error {
+	By(fmt.Sprintf("Taint node %s", node.Name))
+	for j := 0; j < 3; j++ {
+		freshNode, err := driver.targetCluster.Clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		for _, taint := range freshNode.Spec.Taints {
+			if taint.Key == disabledTaint {
+				return nil
+			}
+		}
+		freshNode.Spec.Taints = append(freshNode.Spec.Taints, v1.Taint{
+			Key:    disabledTaint,
+			Value:  "DisabledForTest",
+			Effect: v1.TaintEffectNoSchedule,
+		})
+		_, err = driver.targetCluster.Clientset.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+		klog.Warningf("Got 409 conflict when trying to taint node, retries left: %v", 3-j)
+	}
+	return fmt.Errorf("failed to taint node in allowed number of retries")
+}
+
+// CriticalAddonsOnlyError implements the `error` interface, and signifies the
+// presence of the `CriticalAddonsOnly` taint on the node.
+type CriticalAddonsOnlyError struct{}
+
+func (CriticalAddonsOnlyError) Error() string {
+	return "criticalAddonsOnly taint found on node"
+}
+
+func (driver *Driver) makeNodeSchedulable(node *v1.Node, failOnCriticalAddonsOnly bool) error {
+	By(fmt.Sprintf("Remove taint from node %s", node.Name))
+	for j := 0; j < 3; j++ {
+		freshNode, err := driver.targetCluster.Clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		var newTaints []v1.Taint
+		for _, taint := range freshNode.Spec.Taints {
+			if failOnCriticalAddonsOnly && taint.Key == criticalAddonsOnlyTaint {
+				return CriticalAddonsOnlyError{}
+			}
+			if taint.Key != disabledTaint {
+				newTaints = append(newTaints, taint)
+			}
+		}
+
+		if len(newTaints) == len(freshNode.Spec.Taints) {
+			return nil
+		}
+		freshNode.Spec.Taints = newTaints
+		_, err = driver.targetCluster.Clientset.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
+		if err == nil {
+			return nil
+		}
+		if !apierrors.IsConflict(err) {
+			return err
+		}
+		klog.Warningf("Got 409 conflict when trying to taint node, retries left: %v", 3-j)
+	}
+	return fmt.Errorf("failed to remove taint from node in allowed number of retries")
 }

--- a/cluster-autoscaler/integration/integration_suite_test.go
+++ b/cluster-autoscaler/integration/integration_suite_test.go
@@ -3,11 +3,11 @@ package integration
 import (
 	"testing"
 
-	ginkgo "github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestIntegration(t *testing.T) {
-	gomega.RegisterFailHandler(ginkgo.Fail)
-	ginkgo.RunSpecs(t, "Integration Suite")
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Integration Suite")
 }

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -3,11 +3,13 @@ package integration
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"regexp"
 	"time"
 
-	ginkgo "github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,25 +22,40 @@ var (
 
 	scaleUpWorkload      = "scale-up-pod"
 	initialNumberOfNodes = 1
+	maxNodes             = 4
 )
 
 var driver = NewDriver(controlKubeconfig, targetKubeconfig)
 
-var _ = ginkgo.BeforeSuite(driver.setupBeforeSuite)
-var _ = ginkgo.AfterSuite(driver.cleanup)
+var flag = false
 
-var _ = ginkgo.Describe("Machine controllers test", func() {
+var _ = BeforeSuite(driver.setupBeforeSuite)
+var _ = AfterSuite(driver.cleanup)
+
+var _ = Describe("Cluster Autoscaler test", func() {
 	driver.beforeEachCheck(checkIfClusterAutoscalerUp)
+	driver.afterEachCheck(removeWorkload)
 	driver.controllerTests()
 })
 
 func (driver *Driver) beforeEachCheck(fn func()) {
-	ginkgo.BeforeEach(fn)
+	BeforeEach(fn)
+}
+
+func (driver *Driver) afterEachCheck(fn func()) {
+	AfterEach(fn)
+}
+
+func removeWorkload() {
+	if flag {
+		Expect(driver.deleteWorkload()).To(BeNil())
+	}
+	flag = false
 }
 
 func checkIfClusterAutoscalerUp() {
-	ginkgo.By("Checking autoscaler process is running")
-	gomega.Expect(autoscalerSession.ExitCode()).Should(gomega.Equal(-1))
+	By("Checking autoscaler process is running")
+	Expect(autoscalerSession.ExitCode()).Should(Equal(-1))
 }
 
 func (driver *Driver) setupBeforeSuite() {
@@ -46,69 +63,269 @@ func (driver *Driver) setupBeforeSuite() {
 	driver.adjustNodeGroups()
 	driver.runAutoscaler()
 }
-
-func (driver *Driver) cleanup() {
-	ginkgo.By("Running CleanUp")
-
-	ginkgo.By("Deleting workload")
+func (driver *Driver) deleteWorkload() error {
+	By("Deleting workload")
 	err := driver.targetCluster.Clientset.AppsV1().Deployments("default").DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})
 	if err != nil {
 		fmt.Printf("error cleaning up deployments in target cluster: %s", err.Error())
 	}
+	return err
+}
 
+func (driver *Driver) cleanup() {
+	By("Running CleanUp")
+
+	driver.deleteWorkload()
 	driver.adjustNodeGroups()
+	driver.deleteWorkload()
 
-	ginkgo.By("Scaling CA back up to 1 in the Shoot namespace")
-	err = driver.scaleAutoscaler(1)
+	By("Scaling CA back up to 1 in the Shoot namespace")
+	err := driver.scaleAutoscaler(int32(initialNumberOfNodes))
 	if err != nil {
 		fmt.Printf("error scaling up cluster autoscaler deployment in control cluster Shoot namespace: %s", err.Error())
 	}
 }
 
 func (driver *Driver) controllerTests() {
-	ginkgo.Describe("Scale up and down nodes", func() {
-		ginkgo.Context("by deploying new workload requesting more resources", func() {
-			ginkgo.It("should not lead to any errors and add 1 more node in target cluster", func() {
+	Describe("Scale up and down nodes", func() {
+		Context("by deploying new workload requesting more resources", func() {
+			It("should not lead to any errors and add 1 more node in target cluster", func() {
 
-				ginkgo.By("Deploying workload...")
-				gomega.Expect(driver.deployWorkload(1)).To(gomega.BeNil())
+				By("Deploying workload...")
+				Expect(driver.deployWorkload(1, scaleUpWorkload)).To(BeNil())
 
-				ginkgo.By("Validating Scale up")
-				gomega.Eventually(
+				By("Validating Scale up")
+				Eventually(
 					driver.targetCluster.getNumberOfReadyNodes,
 					pollingTimeout,
 					pollingInterval).
-					Should(gomega.BeNumerically("==", initialNumberOfNodes+1))
+					Should(BeNumerically("==", initialNumberOfNodes+1))
 			})
 		})
 
-		ginkgo.Context("by scaling deployed workload to 3 replicas", func() {
-			ginkgo.It("should not lead to any errors and add 3 more node in target cluster", func() {
+		Context("by scaling deployed workload to 3 replicas", func() {
+			It("should not lead to any errors and add 3 more node in target cluster", func() {
 
-				ginkgo.By("Scaling up workload to 3 replicas...")
-				gomega.Expect(driver.scaleWorkload(scaleUpWorkload, 3)).To(gomega.BeNil())
+				By("Scaling up workload to 3 replicas...")
+				Expect(driver.scaleWorkload(scaleUpWorkload, 3)).To(BeNil())
 
-				ginkgo.By("Validating Scale up")
-				gomega.Eventually(
+				By("Validating Scale up")
+				Eventually(
 					driver.targetCluster.getNumberOfReadyNodes,
 					pollingTimeout,
 					pollingInterval).
-					Should(gomega.BeNumerically("==", initialNumberOfNodes+3))
+					Should(BeNumerically("==", initialNumberOfNodes+3))
 			})
 		})
 
-		ginkgo.Context("by scaling down the deployed workload to 0", func() {
-			ginkgo.It("should not lead to any errors and 3 nodes to be removed from the target cluster", func() {
+		Context("by scaling down the deployed workload to 0", func() {
+			It("should not lead to any errors and 3 nodes to be removed from the target cluster", func() {
 
-				ginkgo.By("Scaling down workload to zero...")
-				gomega.Expect(driver.scaleWorkload(scaleUpWorkload, 0)).To(gomega.BeNil())
+				By("Scaling down workload to zero...")
+				Expect(driver.scaleWorkload(scaleUpWorkload, 0)).To(BeNil())
 
-				ginkgo.By("Validating Scale down")
-				gomega.Eventually(
+				By("Validating Scale down")
+				Eventually(
 					driver.targetCluster.getNumberOfReadyNodes,
 					pollingTimeout,
 					pollingInterval).
-					Should(gomega.BeNumerically("==", initialNumberOfNodes))
+					Should(BeNumerically("==", initialNumberOfNodes))
+				flag = true
+			})
+		})
+	})
+	Describe("testing annotation to skip scaledown", func() {
+		Context("by adding annotation and then scaling the workload to zero", func() {
+			It("should not scale down the extra node and should log correspondingly", func() {
+				By("adding the annotation after deploy workload to 1")
+				Expect(driver.deployWorkload(1, scaleUpWorkload)).To(BeNil())
+				By("Validating Scale up")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", initialNumberOfNodes+1))
+				By("getting the latest added node and adding annotation to it.")
+				_, latestNode, err := driver.getOldestAndLatestNode()
+				Expect(err).To(BeNil())
+				Expect(driver.addAnnotationToNode(latestNode)).To(BeNil())
+				By("Scaling down workload to zero...")
+				Expect(driver.scaleWorkload(scaleUpWorkload, 0)).To(BeNil())
+				skippedRegexp, _ := regexp.Compile(` the node is marked as no scale down`)
+				Eventually(func() bool {
+					data, _ := ioutil.ReadFile(CALogFile)
+					return skippedRegexp.Match(data)
+				}, pollingTimeout, pollingInterval).Should(BeTrue())
+			})
+
+			It("Should remove the unwanted node once scale down disable annotation is removed", func() {
+				Expect(driver.targetCluster.getNumberOfReadyNodes()).Should(BeNumerically("==", initialNumberOfNodes+1))
+				_, latestNode, err := driver.getOldestAndLatestNode()
+				Expect(err).To(BeNil())
+				Expect(driver.removeAnnotationFromNode(latestNode)).To(BeNil())
+				By("Validating Scale down")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", initialNumberOfNodes))
+				flag = true
+			})
+		})
+	})
+	Describe("testing min and max limit for Cluster autoscaler", func() {
+		Context("by increasing the workload to above max", func() {
+			It("shouldn't scale beyond max number of workers", func() {
+				By("Deploying workload with replicas = max+4")
+				Expect(driver.deployWorkload(int32(maxNodes+4), scaleUpWorkload)).To(BeNil())
+				By("Validating Scale up")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", maxNodes))
+			})
+		})
+		Context("by decreasing the workload to below min", func() {
+			It("shouldn't scale down beyond min number of workers", func() {
+				By("Scaling down workload to zero...")
+				Expect(driver.scaleWorkload(scaleUpWorkload, 0)).To(BeNil())
+
+				By("Validating Scale down")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", initialNumberOfNodes))
+				flag = true
+			})
+		})
+	})
+	Describe("testing scaling due to taints", func() {
+		Context("make current nodes unschedulable", func() {
+			It("should spawn more nodes for accommodating new workload", func() {
+				By("making the only node available, to be unschedulable")
+				_, latestNode, err := driver.getOldestAndLatestNode()
+				Expect(err).To(BeNil())
+
+				driver.makeNodeUnschedulable(latestNode)
+
+				By("Increasing the workload")
+				Expect(driver.deploySmallWorkload(1, scaleUpWorkload)).To(BeNil())
+
+				By("Validating Scale up")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", initialNumberOfNodes+1))
+			})
+			It("should remove the node as the taint has been removed and node has low utilization", func() {
+				By("making the node available to be schedulable")
+
+				oldestNode, _, err := driver.getOldestAndLatestNode()
+				Expect(err).To(BeNil())
+				driver.makeNodeSchedulable(oldestNode, false)
+
+				By("Validating Scale down")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", initialNumberOfNodes))
+				flag = true
+			})
+		})
+	})
+	Describe("testing scaling due to volume pending", func() {
+		Context("create a volume in a zone with no node and a pod requesting it", func() {
+			It("should create a node in the zone with volume and hence scale up", func() {
+
+				By("Creating StorageClass with topology restrictions")
+				class := "myclass"
+				provider := os.Getenv("CLUSTER_PROVIDER")
+				if provider != "aws" {
+					return
+				}
+				//TODO: support this testcase for GKE once nodeTemplate in machinedeployment has the label `topology.gke.io/zone`: <zone-name>
+				storageClass, err1 := getStorageClassObject(class)
+
+				if err1 != nil {
+					fmt.Printf("StorageClassObject creation error: %v", err1)
+					return
+				}
+
+				_, err := driver.targetCluster.Clientset.StorageV1().StorageClasses().Create(context.TODO(), storageClass, metav1.CreateOptions{})
+				if err != nil {
+					fmt.Printf("StorageClass Create API error: %v", err)
+				}
+
+				defer func() {
+					By("Removing storage Class created earlier")
+					err := driver.targetCluster.Clientset.StorageV1().StorageClasses().Delete(context.TODO(), class, metav1.DeleteOptions{})
+					if err != nil {
+						fmt.Printf("StorageClass Delete API error: %v", err)
+					}
+				}()
+
+				By("deploying PVC in zone with no nodes")
+
+				claimName := "myclaim"
+				pvc := getPvcObject(claimName, class)
+
+				_, err = driver.targetCluster.Clientset.CoreV1().PersistentVolumeClaims("default").Create(context.TODO(), pvc, metav1.CreateOptions{})
+				if err != nil {
+					fmt.Printf("PVC Create API error: %v", err)
+				}
+
+				defer func() {
+					By("Removing pvc created earlier")
+					err := driver.targetCluster.Clientset.CoreV1().PersistentVolumeClaims("default").Delete(context.TODO(), claimName, metav1.DeleteOptions{})
+					if err != nil {
+						fmt.Printf("StorageClass Delete API error: %v", err)
+					}
+				}()
+
+				By("deploying the workload which requires the volume")
+
+				deploymentName := "volume-pod"
+				deployment := getDeploymentObjectWithVolumeReq(deploymentName, claimName)
+
+				_, err = driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
+				if err != nil {
+					fmt.Printf("Deployment Create API error: %v", err)
+				}
+
+				defer func() {
+					By("Removing deployment created earlier")
+					err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Delete(context.Background(), deploymentName, metav1.DeleteOptions{})
+					if err != nil {
+						fmt.Printf("Deployment Delete API error: %v", err)
+					}
+				}()
+
+				By("Validation scale up to +1 in a new Zone")
+				Eventually(
+					driver.targetCluster.getNumberOfReadyNodes,
+					pollingTimeout,
+					pollingInterval).
+					Should(BeNumerically("==", initialNumberOfNodes+1))
+				flag = true
+			})
+		})
+	})
+	Describe("testing not able to scale due to excess demand", func() {
+		Context("create a pod requiring more resources than a single machine can provide", func() {
+			It("shouldn't scale up and log the error", func() {
+				By("Deploying the workload")
+				Expect(driver.deployLargeWorkload(1, scaleUpWorkload)).To(BeNil())
+				By("checking that scale up didn't trigger because of no machine satisfying the requirement")
+				skippedRegexp, _ := regexp.Compile("Pod large-scale-up-pod-.* can't be scheduled on .*, predicate checking error: Insufficient cpu; predicateName=NodeResourcesFit; reasons: Insufficient cpu;")
+				Eventually(func() bool {
+					data, _ := ioutil.ReadFile(CALogFile)
+					return skippedRegexp.Match(data)
+				}, pollingTimeout, pollingInterval).Should(BeTrue())
+				flag = true
 			})
 		})
 	})

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -155,6 +155,7 @@ skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/
                 "cluster-autoscaler/cloudprovider/hetzner/hcloud-go",
                 "cluster-autoscaler/cloudprovider/mcm",
                 "cluster-autoscaler/integration",
+                "cluster-autoscaler/hack",
                 "cluster-autoscaler/cloudprovider/builder/builder_all.go"
                 ]
 

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -26,6 +26,7 @@ excluded_packages=(
   '/vendor/'
   'vertical-pod-autoscaler/pkg/client'
   'cluster-autoscaler/cloudprovider/magnum/gophercloud'
+  'cluster-autoscaler/integration'
   'cluster-autoscaler/cloudprovider/digitalocean/godo'
   'cluster-autoscaler/cloudprovider/exoscale/internal'
   'cluster-autoscaler/cloudprovider/huaweicloud/huaweicloud-sdk-go-v3'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds few IT to increase the coverage for cluster-autoscaler.
Adds automation for testing locally, such as downloading Kube config and keeping them in the correct directory and modifying makefile accordingly is all now done by a single `make download-kubeconfigs` command.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement developer
more test cases added for local integration tests
```
