### PR TITLE
Cache not to be used to form node-template during scale from zero

### DIFF
--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -99,8 +99,9 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, nodeInfoCache map[string]*schedu
 			continue
 		}
 
-		// No good template, check cache of previously running nodes.
-		if nodeInfoCache != nil {
+		// No good template, check cache of previously running nodes(only when nodeGrp min size is not zero. This is to avoid scenarios where nodeGrp instanceType is updated,
+		// but still cached ol nodeTemplate is used)
+		if nodeInfoCache != nil && nodeGroup.MinSize() != 0 {
 			if nodeInfo, found := nodeInfoCache[id]; found {
 				if nodeInfoCopy, err := deepCopyNodeInfo(nodeInfo); err == nil {
 					result[id] = nodeInfoCopy

--- a/cluster-autoscaler/core/utils/utils.go
+++ b/cluster-autoscaler/core/utils/utils.go
@@ -100,7 +100,7 @@ func GetNodeInfosForGroups(nodes []*apiv1.Node, nodeInfoCache map[string]*schedu
 		}
 
 		// No good template, check cache of previously running nodes(only when nodeGrp min size is not zero. This is to avoid scenarios where nodeGrp instanceType is updated,
-		// but still cached ol nodeTemplate is used)
+		// but still cached old nodeTemplate is used)
 		if nodeInfoCache != nil && nodeGroup.MinSize() != 0 {
 			if nodeInfo, found := nodeInfoCache[id]; found {
 				if nodeInfoCopy, err := deepCopyNodeInfo(nodeInfo); err == nil {

--- a/cluster-autoscaler/core/utils/utils_test.go
+++ b/cluster-autoscaler/core/utils/utils_test.go
@@ -210,7 +210,9 @@ func TestGetNodeInfosForGroupsCache(t *testing.T) {
 	assertEqualNodeCapacities(t, ready2, info.Node())
 	info, found = res["ng4"]
 	assert.True(t, found)
-	assertEqualNodeCapacities(t, ready6, info.Node())
+	/* The below line is commented , as now the nodeTemplate is not formed from previously ready node of nodegrp
+	if nodeGrp has min size 0 */
+	// assertEqualNodeCapacities(t, ready6, info.Node())
 }
 
 func assertEqualNodeCapacities(t *testing.T, expected, actual *apiv1.Node) {


### PR DESCRIPTION
**What this PR does / why we need it**:
NodeTemplate is formed for each nodegroup every time main loop of CA executes. This nodeTemplate is req by CA to perform calculation and finally deciding upon which nodegrp to scale-up. NodeTemplate is formed by 3 options for each nodegrp (in order):
1) from a ready existing node
2) from a previously ready, now non-existent node
3) from template creation function implemented for particular provider (in our case we take values from machineClass in this function)

We have a case when a node got created in a sfz nodegrp , but now its not there. Then every other time the cached nodeTemplate is used for that nodegrp. This could be problematic in case when nodeGrp instance type gets updated , because still the nodeTemplate is based on the old instanceType.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
To resolve the above , the nodeTemplate formation from cache has been disabled for nodeGrps with minSize 0 i.e. the ones which would scale from zero. This will cause CA to form nodeTemplate using the machineClass only.
This change is done in the core part of CA which we usually don't touch.
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
NodeTemplate is not formed using cache in case nodegrp has minimum size zero. This is done to keep nodeTemplate updated even when instance type of nodegrp is updated.
```
