### PR TITLE
Consider failed machine as terminating 

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -868,8 +868,10 @@ func buildGenericLabels(template *nodeTemplate, nodeName string) map[string]stri
 }
 
 // isMachineTerminating returns true if machine is already being terminated or considered for termination by autoscaler.
+// The machine marked `Failed` are also considered terminating now because eventually they will be terminated. This prevents race b/w MCM
+// and CA logic
 func isMachineTerminating(machine *v1alpha1.Machine) bool {
-	if !machine.GetDeletionTimestamp().IsZero() {
+	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
 		klog.Infof("Machine %q is already being terminated, and hence skipping the deletion", machine.Name)
 		return true
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -869,7 +869,8 @@ func buildGenericLabels(template *nodeTemplate, nodeName string) map[string]stri
 
 // isMachineTerminating returns true if machine is already being terminated or considered for termination by autoscaler.
 // The machine marked `Failed` are also considered terminating now because eventually they will be terminated. This prevents race b/w MCM
-// and CA logic
+// and CA logic. However, the logs after this log might suggest that machineDeployment was reduced in size and unregistered nodes were removed
+// but that is because we don't return error if this race condition happens.
 func isMachineTerminating(machine *v1alpha1.Machine) bool {
 	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
 		klog.Infof("Machine %q is already being terminated, and hence skipping the deletion", machine.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:
CA will now consider Failed machine as Terminating to avoid race with MCM in case of machine not joining in 20min.
**Which issue(s) this PR fixes**:
Fixes #118 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement user
Race b/w MCM and Cluster Autoscaler in case of node joining timeout is fixed
```

/invite @unmarshall 