### PR TITLE
Updated pipeline go version to 1.18.3

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -60,7 +60,7 @@ fi
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
 # to build for linux OS, amd64 architectures and without CGO enablement.
 if [[ -z "$LOCAL_BUILD" ]]; then
-  go build \
+  GO111MODULE=off go build \
     -a \
     -v \
     -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler \
@@ -68,7 +68,7 @@ if [[ -z "$LOCAL_BUILD" ]]; then
 
 # If the LOCAL_BUILD environment variable is set, we simply run `go build`.
 else
-  go build \
+  GO111MODULE=off go build \
     -v \
     -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler \
     cluster-autoscaler/main.go

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,9 +21,9 @@ autoscaler:
             dir: 'cluster-autoscaler'
     steps:
       test:
-        image: 'golang:1.15.0'
+        image: 'golang:1.18.3'
       build:
-        image: 'golang:1.15.0'
+        image: 'golang:1.18.3'
         output_dir: 'binary'
   jobs:
     head-update:

--- a/.ci/test
+++ b/.ci/test
@@ -50,8 +50,8 @@ fi
 
 ##############################################################################
 
-go test $(go list ./cluster-autoscaler/... | grep -v cloudprovider | grep -v vendor | grep -v integration)
-go test $(go list ./cluster-autoscaler/cloudprovider/mcm/... | grep -v vendor)
+GO111MODULE=off go test $(go list ./cluster-autoscaler/... | grep -v cloudprovider | grep -v vendor | grep -v integration)
+GO111MODULE=off go test $(go list ./cluster-autoscaler/cloudprovider/mcm/... | grep -v vendor)
 
 #TODO: Return success failure properly
 echo "CI tests are done"


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the pipeline definition to use go 1.18.3 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update Go version used in the pipeline to `v1.18.3`
```
