### PR TITLE
Updated pipeline go version to 1.18.3

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -21,9 +21,9 @@ autoscaler:
             dir: 'cluster-autoscaler'
     steps:
       test:
-        image: 'golang:1.16.0'
+        image: 'golang:1.18.3'
       build:
-        image: 'golang:1.16.0'
+        image: 'golang:1.18.3'
         output_dir: 'binary'
   jobs:
     head-update:


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates the pipeline definition to use go 1.18.3


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
Update Go version used in the pipeline to `v1.18.3`
```
