### PR TITLE
Set GOOS,GOARCH env and ldflags option in .ci/build file

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -59,11 +59,11 @@ fi
 
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
 # to build for linux OS, amd64 architectures and without CGO enablement.
+# ldflags used, same as Makefile , this reduces size of binary considerably
 if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build --ldflags="-s -w" \
     -a \
     -v \
-    -ldflags="-s" \  #default value as per Makefile used, this reduces size of binary considerably
     -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler-amd64 \
     cluster-autoscaler/main.go
 

--- a/.ci/build
+++ b/.ci/build
@@ -60,9 +60,10 @@ fi
 # If no LOCAL_BUILD environment variable is set, we configure the `go build` command
 # to build for linux OS, amd64 architectures and without CGO enablement.
 if [[ -z "$LOCAL_BUILD" ]]; then
-  GO111MODULE=off go build \
+  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build \
     -a \
     -v \
+    -ldflags="-s" \  #default value as per Makefile used, this reduces size of binary considerably
     -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler-amd64 \
     cluster-autoscaler/main.go
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Bring .ci/build in sync with Makefile way of creating binary. This is required after we started using `gcr.io/distroless/static:latest-amd64` image in `Dockerfile.amd64`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- done only for amd64 architecture
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Bug stopping autoscaler to run because of architecture incompatibility is fixed
```
