### PR TITLE
[rel-v1.22] Cherry pick of #161: Build Multi-Arch Images

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -38,39 +38,13 @@ else
   export BINARY_PATH="$(${READLINK_BIN} -f "${BINARY_PATH}")"
 fi
 
-# The `go <cmd>` commands requires to see the target repository to be part of a
-# Go workspace. Thus, if we are not yet in a Go workspace, let's create one
-# temporarily by using symbolic links.
-if [[ "${SOURCE_PATH}" != *"src/k8s.io/autoscaler" ]]; then
-  SOURCE_SYMLINK_PATH="${SOURCE_PATH}/tmp/src/k8s.io/autoscaler"
-  if [[ -d "${SOURCE_PATH}/tmp" ]]; then
-    rm -rf "${SOURCE_PATH}/tmp"
-  fi
-  mkdir -p "${SOURCE_PATH}/tmp/src/k8s.io"
-  ln -s "${SOURCE_PATH}" "${SOURCE_SYMLINK_PATH}"
-  cd "${SOURCE_SYMLINK_PATH}"
-
-  export GOPATH="${SOURCE_PATH}/tmp"
-  export GOBIN="${SOURCE_PATH}/tmp/bin"
-  export PATH="${GOBIN}:${PATH}"
-fi
-
 ###############################################################################
 
-# If no LOCAL_BUILD environment variable is set, we configure the `go build` command
-# to build for linux OS, amd64 architectures and without CGO enablement.
+# Change to cluster-autoscaler directory that we can build with modules
+cd ${SOURCE_PATH}/cluster-autoscaler
 # ldflags used, same as Makefile , this reduces size of binary considerably
-if [[ -z "$LOCAL_BUILD" ]]; then
-  CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=off go build --ldflags="-s -w" \
-    -a \
-    -v \
-    -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler \
-    cluster-autoscaler/main.go
-
-# If the LOCAL_BUILD environment variable is set, we simply run `go build`.
-else
-  GO111MODULE=off go build \
-    -v \
-    -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler \
-    cluster-autoscaler/main.go
-fi
+CGO_ENABLED=0 GO111MODULE=on go build --ldflags="-s -w" \
+  -v \
+  -mod=vendor \
+  -o ${BINARY_PATH}/cluster-autoscaler/cluster-autoscaler \
+  main.go

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -8,6 +8,10 @@ autoscaler:
           'inject-commit-hash'
         inject_effective_version: true
       publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
         dockerimages:
           cluster-autoscaler:
             inputs:
@@ -17,13 +21,12 @@ autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler'
-            dockerfile: 'Dockerfile'
-            dir: 'cluster-autoscaler'
+            dockerfile: './cluster-autoscaler/Dockerfile'
     steps:
       test:
-        image: 'golang:1.18.3'
+        image: 'golang:1.18.10'
       build:
-        image: 'golang:1.18.3'
+        image: 'golang:1.18.10'
         output_dir: 'binary'
   jobs:
     head-update:

--- a/cluster-autoscaler/Dockerfile
+++ b/cluster-autoscaler/Dockerfile
@@ -1,19 +1,18 @@
-# Copyright 2016 The Kubernetes Authors. All rights reserved
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-ARG BASEIMAGE=gcr.io/distroless/static:latest-amd64
-FROM $BASEIMAGE
-LABEL maintainer="Marcin Wielgus <mwielgus@google.com>"
+#############      builder                                  #############
+FROM golang:1.18.10 AS builder
 
-COPY cluster-autoscaler /
+WORKDIR /go/src/github.com/gardener/autoscaler
+COPY . .
+
+RUN .ci/build
+
+#############      base                                     #############
+FROM gcr.io/distroless/static-debian11:nonroot as base
+WORKDIR /
+
+#############      cluster-autoscaler               #############
+FROM base AS cluster-autoscaler
+
+COPY --from=builder /go/src/github.com/gardener/autoscaler/cluster-autoscaler/cluster-autoscaler /cluster-autoscaler
+
 CMD ["/cluster-autoscaler"]


### PR DESCRIPTION
Cherry pick of #161 

**What this PR does / why we need it**:
This PR enables the CI pipeline to publish multi-arch images with support for linux/amd64 and linux/arm64.

**Which issue(s) this PR fixes**:
Fixes parts of https://github.com/gardener/gardener/issues/6258

**Special notes for your reviewer**:
I created a new `Dockerfile` for `cluster-autoscaler` which is easier to use in `docker-buildx` environment.

This PR uses the latest Go 1.18 instead of Go 1.19 in the original PR. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Docker images for cluster-autoscaler are published with multi-arch support for `linux/amd64` and `linux/arm64` now.
Update Go version to `1.18.10`.
```
