### PR TITLE
Configure scanning-hint CD source label

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,7 +1,16 @@
 autoscaler:
   template: 'default'
   base_definition:
-    repo: ~
+    repo:
+      source_labels:
+      - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
+        value:
+          policy: 'scan'
+          path_config:
+            exclude_paths:
+              - '.*/aws-sdk-go/.*'
+              - '^vendor/.*'
+              - '.*/vendor/.*'
     traits:
       version:
         preprocess:


### PR DESCRIPTION
**What this PR does / why we need it**:
Vendored packages are excluded from codescans. `aws-sdk-go` is a special case as a copy outside of vendor folder was introduced with https://github.com/gardener/autoscaler/commit/6ff006f4d9bcff647a365666ee6d8c60bd3f34d9.
The source label is configured as described in [Pipeline Job, Repository Attribute Documentation](https://gardener.github.io/cc-utils/pipeline_job.html).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
vendored packages are excluded from checkmarx scans
```
