### PR TITLE
Configure Scanning Label for CA

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -12,6 +12,8 @@ autoscaler:
               - '^vendor/.*'
               - '.*/vendor/.*'
               - '.*/cloudprovider/(?!mcm)/.*'
+              - '^addon-resizer/.*'
+              - '^vertical-pod-autoscaler/.*'
     traits:
       version:
         preprocess:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -11,7 +11,7 @@ autoscaler:
               - '.*/aws-sdk-go/.*'
               - '^vendor/.*'
               - '.*/vendor/.*'
-              - '.*/cloudprovider/(?!mcm)/.*'
+              - '.*/cloudprovider/((?!mcm/).)*/.*'
               - '^addon-resizer/.*'
               - '^vertical-pod-autoscaler/.*'
     traits:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -11,6 +11,7 @@ autoscaler:
               - '.*/aws-sdk-go/.*'
               - '^vendor/.*'
               - '.*/vendor/.*'
+              - '.*/cloudprovider/(?!mcm)/.*'
     traits:
       version:
         preprocess:


### PR DESCRIPTION
**What this PR does / why we need it**:
We would like to exclude implementations of other cloudproviders in autoscaler, from getting scanned for vulnerabilities in checkmarx. Cloud providers other than `MCM` are excluded from codescans.
Essentially every code path traversed with `mcm` as cloudprovider (including the core logic) will be scanned now.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The current regex has one limitation. The kind `/cloudprovider/+*mcm/.*` paths will still be included in codescans.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
cloud providers other than `MCM` are excluded from checkmarx scans.
```
