### PR TITLE
Updates in IT

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -123,6 +123,8 @@ start:
 			--scale-down-delay-after-add=10s \
 			--scale-down-delay-after-failure=2s \
 			--v=4 \
+			--ignore-taint=node.gardener.cloud/critical-components-not-ready \
+			--ignore-taint=testing.node.gardener.cloud/initial-node-blocked \
 			--expander=least-waste \
 			--scale-down-unneeded-time=5s \
 			--balance-similar-node-groups=true \

--- a/cluster-autoscaler/integration/framework.go
+++ b/cluster-autoscaler/integration/framework.go
@@ -31,13 +31,14 @@ const (
 )
 
 var (
-	criticalAddonsOnlyTaint = "CriticalAddonsOnly"
-	disabledTaint           = "DisabledForAutoscalingTest"
-	smallMemory             = "50Mi"
-	mediumMemory            = "150Mi"
-	largeMemory             = "500Mi"
-	smallCPU                = "500m"
-	cpuResource             int64
+	criticalAddonsOnlyTaint             = "CriticalAddonsOnly"
+	disabledTaint                       = "DisabledForAutoscalingTest"
+	blockInitialNodesForSchedulingTaint = "testing.node.gardener.cloud/initial-node-blocked"
+	smallMemory                         = *resource.NewQuantity(50*1024*1024, resource.BinarySI)
+	mediumMemory                        = *resource.NewQuantity(150*1024*1024, resource.BinarySI)
+	largeMemory                         = *resource.NewQuantity(500*1024*1024, resource.BinarySI)
+	smallCPU                            = *resource.NewMilliQuantity(500, resource.DecimalSI)
+	cpuResource                         *resource.Quantity
 )
 
 // rotateLogFile takes file name as input and returns a file object obtained by os.Create
@@ -52,6 +53,28 @@ func rotateLogFile(fileName string) (*os.File, error) {
 	}
 
 	return os.Create(fileName)
+}
+
+func (driver *Driver) taintOrUnTaintInitialNodes(toTaint bool) error {
+	if toTaint {
+		gin.By("Marking nodes present before the tests as unschedulable")
+		nodes, _ := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		for _, n := range nodes.Items {
+			if err := driver.addTaintsToNode(&n, map[string]bool{blockInitialNodesForSchedulingTaint: true}); err != nil {
+				return err
+			}
+		}
+	} else {
+		gin.By("Turning nodes present before the tests, back to schedulable")
+		nodes, _ := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		// marking every node schedulable as this method is called either in BeforeSuite() or AfterSuite()
+		for _, n := range nodes.Items {
+			if err := driver.removeTaintsFromNode(&n, false, map[string]bool{blockInitialNodesForSchedulingTaint: true}); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func (driver *Driver) adjustNodeGroups() error {
@@ -94,7 +117,7 @@ func (c *Cluster) getNumberOfReadyNodes() int16 {
 	nodes, _ := c.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	count := 0
 	for _, n := range nodes.Items {
-		cpuResource, _ = (n.Status.Capacity.Cpu()).AsInt64()
+		cpuResource = n.Status.Capacity.Cpu()
 		for _, nodeCondition := range n.Status.Conditions {
 			if nodeCondition.Type == "Ready" && nodeCondition.Status == "True" {
 				count++
@@ -284,7 +307,7 @@ func getDeploymentObjectWithVolumeReq(deploymentName string, claimName string) *
 	return deployment
 }
 
-func getDeploymentObject(replicas int32, resourceCpu string, resourceMemory string, workloadName string) *appv1.Deployment {
+func getDeploymentObject(replicas int32, resourceCpu resource.Quantity, resourceMemory resource.Quantity, workloadName string, tolerations []v1.Toleration) *appv1.Deployment {
 	deployment := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workloadName,
@@ -315,12 +338,13 @@ func getDeploymentObject(replicas int32, resourceCpu string, resourceMemory stri
 							},
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resource.MustParse(resourceCpu),
-									v1.ResourceMemory: resource.MustParse(resourceMemory),
+									v1.ResourceCPU:    resourceCpu,
+									v1.ResourceMemory: resourceMemory,
 								},
 							},
 						},
 					},
+					Tolerations: tolerations,
 				},
 			},
 		},
@@ -328,8 +352,24 @@ func getDeploymentObject(replicas int32, resourceCpu string, resourceMemory stri
 	return deployment
 }
 
-func (driver *Driver) deployWorkload(replicas int32, workloadName string) error {
-	deployment := getDeploymentObject(replicas, fmt.Sprint(cpuResource-1), mediumMemory, workloadName)
+func (driver *Driver) deployWorkload(replicas int32, workloadName string, canTolerateTaintPlacedOnInitialNodes bool) error {
+	// TODO(himanshu-kun): Remove such a dependency on approximating system components space . This changes over time.
+	assumedSystemComponentsUsedSpace := *resource.NewMilliQuantity(1000, resource.DecimalSI)
+	cpuRequested := cpuResource.DeepCopy()
+	cpuRequested.Sub(assumedSystemComponentsUsedSpace)
+	tolerationsToInitialNodeTaint := []v1.Toleration{
+		{
+			Key:      blockInitialNodesForSchedulingTaint,
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+	var deployment *appv1.Deployment
+	if canTolerateTaintPlacedOnInitialNodes {
+		deployment = getDeploymentObject(replicas, cpuRequested, mediumMemory, workloadName, tolerationsToInitialNodeTaint)
+	} else {
+		deployment = getDeploymentObject(replicas, cpuRequested, mediumMemory, workloadName, nil)
+	}
 	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -337,8 +377,24 @@ func (driver *Driver) deployWorkload(replicas int32, workloadName string) error 
 	return nil
 }
 
-func (driver *Driver) deployLargeWorkload(replicas int32, workloadName string) error {
-	deployment := getDeploymentObject(replicas, fmt.Sprint(cpuResource+1), largeMemory, "large-"+workloadName)
+func (driver *Driver) deployLargeWorkload(replicas int32, workloadName string, canTolerateTaintPlacedOnInitialNodes bool) error {
+	// TODO(himanshu-kun): Remove such an approximation
+	extraCPURequest := *resource.NewMilliQuantity(1000, resource.DecimalSI)
+	cpuRequested := cpuResource.DeepCopy()
+	cpuRequested.Add(extraCPURequest)
+	tolerationsToInitialNodeTaint := []v1.Toleration{
+		{
+			Key:      blockInitialNodesForSchedulingTaint,
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+	var deployment *appv1.Deployment
+	if canTolerateTaintPlacedOnInitialNodes {
+		deployment = getDeploymentObject(replicas, cpuRequested, largeMemory, "large-"+workloadName, tolerationsToInitialNodeTaint)
+	} else {
+		deployment = getDeploymentObject(replicas, cpuRequested, largeMemory, "large-"+workloadName, nil)
+	}
 	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -346,8 +402,20 @@ func (driver *Driver) deployLargeWorkload(replicas int32, workloadName string) e
 	return nil
 }
 
-func (driver *Driver) deploySmallWorkload(replicas int32, workloadName string) error {
-	deployment := getDeploymentObject(replicas, smallCPU, smallMemory, "small-"+workloadName)
+func (driver *Driver) deploySmallWorkload(replicas int32, workloadName string, canTolerateTaintPlacedOnInitialNodes bool) error {
+	tolerationsToInitialNodeTaint := []v1.Toleration{
+		{
+			Key:      blockInitialNodesForSchedulingTaint,
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
+	var deployment *appv1.Deployment
+	if canTolerateTaintPlacedOnInitialNodes {
+		deployment = getDeploymentObject(replicas, smallCPU, smallMemory, "small-"+workloadName, tolerationsToInitialNodeTaint)
+	} else {
+		deployment = getDeploymentObject(replicas, smallCPU, smallMemory, "small-"+workloadName, nil)
+	}
 	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		return err
@@ -407,23 +475,30 @@ func (driver *Driver) removeAnnotationFromNode(node *v1.Node) error {
 	return nil
 }
 
-func (driver *Driver) makeNodeUnschedulable(node *v1.Node) error {
+// CriticalAddonsOnlyError implements the `error` interface, and signifies the
+// presence of the `CriticalAddonsOnly` taint on the node.
+type CriticalAddonsOnlyError struct{}
+
+func (CriticalAddonsOnlyError) Error() string {
+	return "criticalAddonsOnly taint found on node"
+}
+
+func (driver *Driver) addTaintsToNode(node *v1.Node, taintKeysToAdd map[string]bool) error {
 	gin.By(fmt.Sprintf("Taint node %s", node.Name))
 	for j := 0; j < 3; j++ {
 		freshNode, err := driver.targetCluster.Clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		for _, taint := range freshNode.Spec.Taints {
-			if taint.Key == disabledTaint {
-				return nil
-			}
+
+		for taintKey, _ := range taintKeysToAdd {
+			freshNode.Spec.Taints = append(freshNode.Spec.Taints, v1.Taint{
+				Key:    taintKey,
+				Value:  "true",
+				Effect: v1.TaintEffectNoSchedule,
+			})
 		}
-		freshNode.Spec.Taints = append(freshNode.Spec.Taints, v1.Taint{
-			Key:    disabledTaint,
-			Value:  "DisabledForTest",
-			Effect: v1.TaintEffectNoSchedule,
-		})
+
 		_, err = driver.targetCluster.Clientset.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
 		if err == nil {
 			return nil
@@ -436,16 +511,12 @@ func (driver *Driver) makeNodeUnschedulable(node *v1.Node) error {
 	return fmt.Errorf("failed to taint node in allowed number of retries")
 }
 
-// CriticalAddonsOnlyError implements the `error` interface, and signifies the
-// presence of the `CriticalAddonsOnly` taint on the node.
-type CriticalAddonsOnlyError struct{}
+func (driver *Driver) removeTaintsFromNode(node *v1.Node, failIfCriticalAddonsOnlyTaintPresent bool, taintKeysToRemove map[string]bool) error {
+	if len(taintKeysToRemove) == 0 {
+		return nil
+	}
 
-func (CriticalAddonsOnlyError) Error() string {
-	return "criticalAddonsOnly taint found on node"
-}
-
-func (driver *Driver) makeNodeSchedulable(node *v1.Node, failOnCriticalAddonsOnly bool) error {
-	gin.By(fmt.Sprintf("Remove taint from node %s", node.Name))
+	gin.By(fmt.Sprintf("Remove taint(s) from node %s", node.Name))
 	for j := 0; j < 3; j++ {
 		freshNode, err := driver.targetCluster.Clientset.CoreV1().Nodes().Get(context.TODO(), node.Name, metav1.GetOptions{})
 		if err != nil {
@@ -453,17 +524,14 @@ func (driver *Driver) makeNodeSchedulable(node *v1.Node, failOnCriticalAddonsOnl
 		}
 		var newTaints []v1.Taint
 		for _, taint := range freshNode.Spec.Taints {
-			if failOnCriticalAddonsOnly && taint.Key == criticalAddonsOnlyTaint {
+			if failIfCriticalAddonsOnlyTaintPresent && taint.Key == criticalAddonsOnlyTaint {
 				return CriticalAddonsOnlyError{}
 			}
-			if taint.Key != disabledTaint {
+			if _, present := taintKeysToRemove[taint.Key]; !present {
 				newTaints = append(newTaints, taint)
 			}
 		}
 
-		if len(newTaints) == len(freshNode.Spec.Taints) {
-			return nil
-		}
 		freshNode.Spec.Taints = newTaints
 		_, err = driver.targetCluster.Clientset.CoreV1().Nodes().Update(context.TODO(), freshNode, metav1.UpdateOptions{})
 		if err == nil {

--- a/cluster-autoscaler/integration/framework.go
+++ b/cluster-autoscaler/integration/framework.go
@@ -25,9 +25,9 @@ import (
 )
 
 const (
-	//annotaion which makes dwd skip the scaling of component
+	// annotaion which makes dwd skip the scaling of component
 	dwdAnnotation string = "dependency-watchdog.gardener.cloud/ignore-scaling"
-	//annotaion to skip the scaling down of exrta/unused node.
+	// annotaion to skip the scaling down of exrta/unused node.
 	ignoreScaledownAnnotation string = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
 
 	pollingTimeout       = 300 * time.Second
@@ -44,6 +44,13 @@ var (
 	largeMemory                         = *resource.NewQuantity(500*1024*1024, resource.BinarySI)
 	smallCPU                            = *resource.NewMilliQuantity(500, resource.DecimalSI)
 	cpuResource                         *resource.Quantity
+	tolerationsToInitialNodeTaint       = []v1.Toleration{
+		{
+			Key:      blockInitialNodesForSchedulingTaint,
+			Operator: v1.TolerationOpExists,
+			Effect:   v1.TaintEffectNoSchedule,
+		},
+	}
 )
 
 // rotateLogFile takes file name as input and returns a file object obtained by os.Create
@@ -363,13 +370,6 @@ func (driver *Driver) deployWorkload(replicas int32, workloadName string, canTol
 	assumedSystemComponentsUsedSpace := *resource.NewMilliQuantity(1000, resource.DecimalSI)
 	approxCPURequested := cpuResource.DeepCopy()
 	approxCPURequested.Sub(assumedSystemComponentsUsedSpace)
-	tolerationsToInitialNodeTaint := []v1.Toleration{
-		{
-			Key:      blockInitialNodesForSchedulingTaint,
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-	}
 	var deployment *appv1.Deployment
 	if canTolerateTaintPlacedOnInitialNodes {
 		deployment = getDeploymentObject(replicas, approxCPURequested, mediumMemory, workloadName, tolerationsToInitialNodeTaint)
@@ -388,13 +388,6 @@ func (driver *Driver) deployLargeWorkload(replicas int32, workloadName string, c
 	extraCPURequest := *resource.NewMilliQuantity(1000, resource.DecimalSI)
 	cpuRequested := cpuResource.DeepCopy()
 	cpuRequested.Add(extraCPURequest)
-	tolerationsToInitialNodeTaint := []v1.Toleration{
-		{
-			Key:      blockInitialNodesForSchedulingTaint,
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-	}
 	var deployment *appv1.Deployment
 	if canTolerateTaintPlacedOnInitialNodes {
 		deployment = getDeploymentObject(replicas, cpuRequested, largeMemory, "large-"+workloadName, tolerationsToInitialNodeTaint)
@@ -409,13 +402,6 @@ func (driver *Driver) deployLargeWorkload(replicas int32, workloadName string, c
 }
 
 func (driver *Driver) deploySmallWorkload(replicas int32, workloadName string, canTolerateTaintPlacedOnInitialNodes bool) error {
-	tolerationsToInitialNodeTaint := []v1.Toleration{
-		{
-			Key:      blockInitialNodesForSchedulingTaint,
-			Operator: v1.TolerationOpExists,
-			Effect:   v1.TaintEffectNoSchedule,
-		},
-	}
 	var deployment *appv1.Deployment
 	if canTolerateTaintPlacedOnInitialNodes {
 		deployment = getDeploymentObject(replicas, smallCPU, smallMemory, "small-"+workloadName, tolerationsToInitialNodeTaint)
@@ -454,7 +440,7 @@ func (driver *Driver) getOldestAndLatestNode() (*v1.Node, *v1.Node, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	//sorting in ascending order of creation timeStamp
+	// sorting in ascending order of creation timeStamp
 	sort.Slice(nodeList.Items, func(i, j int) bool {
 		return nodeList.Items[i].ObjectMeta.CreationTimestamp.Before(&nodeList.Items[j].ObjectMeta.CreationTimestamp)
 	})

--- a/cluster-autoscaler/integration/framework.go
+++ b/cluster-autoscaler/integration/framework.go
@@ -307,7 +307,7 @@ func getDeploymentObjectWithVolumeReq(deploymentName string, claimName string) *
 	return deployment
 }
 
-func getDeploymentObject(replicas int32, resourceCpu resource.Quantity, resourceMemory resource.Quantity, workloadName string, tolerations []v1.Toleration) *appv1.Deployment {
+func getDeploymentObject(replicas int32, resourceCPU resource.Quantity, resourceMemory resource.Quantity, workloadName string, tolerations []v1.Toleration) *appv1.Deployment {
 	deployment := &appv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workloadName,
@@ -338,7 +338,7 @@ func getDeploymentObject(replicas int32, resourceCpu resource.Quantity, resource
 							},
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
-									v1.ResourceCPU:    resourceCpu,
+									v1.ResourceCPU:    resourceCPU,
 									v1.ResourceMemory: resourceMemory,
 								},
 							},
@@ -491,7 +491,7 @@ func (driver *Driver) addTaintsToNode(node *v1.Node, taintKeysToAdd map[string]b
 			return err
 		}
 
-		for taintKey, _ := range taintKeysToAdd {
+		for taintKey := range taintKeysToAdd {
 			freshNode.Spec.Taints = append(freshNode.Spec.Taints, v1.Taint{
 				Key:    taintKey,
 				Value:  "true",

--- a/cluster-autoscaler/integration/framework.go
+++ b/cluster-autoscaler/integration/framework.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"sort"
 	"strings"
+	"time"
 
 	"k8s.io/client-go/util/retry"
 
@@ -28,6 +29,10 @@ const (
 	dwdAnnotation string = "dependency-watchdog.gardener.cloud/ignore-scaling"
 	//annotaion to skip the scaling down of exrta/unused node.
 	ignoreScaledownAnnotation string = "cluster-autoscaler.kubernetes.io/scale-down-disabled"
+
+	pollingTimeout       = 300 * time.Second
+	pollingInterval      = 2 * time.Second
+	initialNumberOfNodes = 1
 )
 
 var (
@@ -55,23 +60,24 @@ func rotateLogFile(fileName string) (*os.File, error) {
 	return os.Create(fileName)
 }
 
-func (driver *Driver) taintOrUnTaintInitialNodes(toTaint bool) error {
-	if toTaint {
-		gin.By("Marking nodes present before the tests as unschedulable")
-		nodes, _ := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-		for _, n := range nodes.Items {
-			if err := driver.addTaintsToNode(&n, map[string]bool{blockInitialNodesForSchedulingTaint: true}); err != nil {
-				return err
-			}
+func (driver *Driver) addTaintsToInitialNodes() error {
+	gin.By("Marking nodes present before the tests as unschedulable")
+	nodes, _ := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	for _, n := range nodes.Items {
+		if err := driver.addTaintsToNode(&n, map[string]bool{blockInitialNodesForSchedulingTaint: true}); err != nil {
+			return fmt.Errorf("some initial nodes might be tainted, tainting node %s failed with err: %q , aborting operation", n.Name, err)
 		}
-	} else {
-		gin.By("Turning nodes present before the tests, back to schedulable")
-		nodes, _ := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-		// marking every node schedulable as this method is called either in BeforeSuite() or AfterSuite()
-		for _, n := range nodes.Items {
-			if err := driver.removeTaintsFromNode(&n, false, map[string]bool{blockInitialNodesForSchedulingTaint: true}); err != nil {
-				return err
-			}
+	}
+	return nil
+}
+
+func (driver *Driver) removeTaintsFromInitialNodes() error {
+	gin.By("Turning nodes present before the tests, back to schedulable")
+	nodes, _ := driver.targetCluster.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+	// marking every node schedulable as this method is called either in BeforeSuite() or AfterSuite()
+	for _, n := range nodes.Items {
+		if err := driver.removeTaintsFromNode(&n, false, map[string]bool{blockInitialNodesForSchedulingTaint: true}); err != nil {
+			return fmt.Errorf("some initial nodes might be left tainted, removing taint from node %s failed with err: %q , aborting operation", n.Name, err)
 		}
 	}
 	return nil
@@ -355,8 +361,8 @@ func getDeploymentObject(replicas int32, resourceCPU resource.Quantity, resource
 func (driver *Driver) deployWorkload(replicas int32, workloadName string, canTolerateTaintPlacedOnInitialNodes bool) error {
 	// TODO(himanshu-kun): Remove such a dependency on approximating system components space . This changes over time.
 	assumedSystemComponentsUsedSpace := *resource.NewMilliQuantity(1000, resource.DecimalSI)
-	cpuRequested := cpuResource.DeepCopy()
-	cpuRequested.Sub(assumedSystemComponentsUsedSpace)
+	approxCPURequested := cpuResource.DeepCopy()
+	approxCPURequested.Sub(assumedSystemComponentsUsedSpace)
 	tolerationsToInitialNodeTaint := []v1.Toleration{
 		{
 			Key:      blockInitialNodesForSchedulingTaint,
@@ -366,9 +372,9 @@ func (driver *Driver) deployWorkload(replicas int32, workloadName string, canTol
 	}
 	var deployment *appv1.Deployment
 	if canTolerateTaintPlacedOnInitialNodes {
-		deployment = getDeploymentObject(replicas, cpuRequested, mediumMemory, workloadName, tolerationsToInitialNodeTaint)
+		deployment = getDeploymentObject(replicas, approxCPURequested, mediumMemory, workloadName, tolerationsToInitialNodeTaint)
 	} else {
-		deployment = getDeploymentObject(replicas, cpuRequested, mediumMemory, workloadName, nil)
+		deployment = getDeploymentObject(replicas, approxCPURequested, mediumMemory, workloadName, nil)
 	}
 	_, err := driver.targetCluster.Clientset.AppsV1().Deployments("default").Create(context.Background(), deployment, metav1.CreateOptions{})
 	if err != nil {

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -4,26 +4,21 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/client-go/util/retry"
 	"os"
 	"regexp"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
 )
 
 var (
 	controlKubeconfig = os.Getenv("CONTROL_KUBECONFIG")
 	targetKubeconfig  = os.Getenv("TARGET_KUBECONFIG")
 
-	pollingTimeout  = 300 * time.Second
-	pollingInterval = 2 * time.Second
-
-	scaleUpWorkload      = "scale-up-pod"
-	initialNumberOfNodes = 1
-	maxNodes             = 4
+	scaleUpWorkload = "scale-up-pod"
+	maxNodes        = 4
 )
 
 var driver = NewDriver(controlKubeconfig, targetKubeconfig)
@@ -60,9 +55,10 @@ func checkIfClusterAutoscalerUp() {
 }
 
 func (driver *Driver) setupBeforeSuite() {
+	// TODO: add gomega assertions, available from MCM release v0.49.0. Example https://github.com/gardener/machine-controller-manager/blob/a03d0fbcd28ef2265adb57d095c5d0d3333d6043/pkg/test/integration/common/framework.go#L1230-L1233
 	driver.scaleAutoscaler(0)
 	driver.adjustNodeGroups()
-	driver.taintOrUnTaintInitialNodes(true)
+	driver.addTaintsToInitialNodes()
 	driver.runAutoscaler()
 }
 func (driver *Driver) deleteWorkload() error {
@@ -77,10 +73,11 @@ func (driver *Driver) deleteWorkload() error {
 func (driver *Driver) cleanup() {
 	By("Running CleanUp")
 
+	// TODO: add gomega assertions, available from MCM release v0.49.0. Example https://github.com/gardener/machine-controller-manager/blob/a03d0fbcd28ef2265adb57d095c5d0d3333d6043/pkg/test/integration/common/framework.go#L1230-L1233
 	driver.deleteWorkload()
 	driver.adjustNodeGroups()
 	driver.deleteWorkload()
-	driver.taintOrUnTaintInitialNodes(false)
+	driver.removeTaintsFromInitialNodes()
 
 	By("Scaling CA back up to 1 in the Shoot namespace")
 	err := driver.scaleAutoscaler(int32(initialNumberOfNodes))

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -62,6 +62,7 @@ func checkIfClusterAutoscalerUp() {
 func (driver *Driver) setupBeforeSuite() {
 	driver.scaleAutoscaler(0)
 	driver.adjustNodeGroups()
+	driver.taintOrUnTaintInitialNodes(true)
 	driver.runAutoscaler()
 }
 func (driver *Driver) deleteWorkload() error {
@@ -79,6 +80,7 @@ func (driver *Driver) cleanup() {
 	driver.deleteWorkload()
 	driver.adjustNodeGroups()
 	driver.deleteWorkload()
+	driver.taintOrUnTaintInitialNodes(false)
 
 	By("Scaling CA back up to 1 in the Shoot namespace")
 	err := driver.scaleAutoscaler(int32(initialNumberOfNodes))
@@ -93,7 +95,7 @@ func (driver *Driver) controllerTests() {
 			It("should not lead to any errors and add 1 more node in target cluster", func() {
 
 				By("Deploying workload...")
-				Expect(driver.deployWorkload(1, scaleUpWorkload)).To(BeNil())
+				Expect(driver.deployWorkload(1, scaleUpWorkload, false)).To(BeNil())
 
 				By("Validating Scale up")
 				Eventually(
@@ -139,7 +141,7 @@ func (driver *Driver) controllerTests() {
 		Context("by adding annotation and then scaling the workload to zero", func() {
 			It("should not scale down the extra node and should log correspondingly", func() {
 				By("adding the annotation after deploy workload to 1")
-				Expect(driver.deployWorkload(1, scaleUpWorkload)).To(BeNil())
+				Expect(driver.deployWorkload(1, scaleUpWorkload, false)).To(BeNil())
 				By("Validating Scale up")
 				Eventually(
 					driver.targetCluster.getNumberOfReadyNodes,
@@ -185,7 +187,7 @@ func (driver *Driver) controllerTests() {
 		Context("by increasing the workload to above max", func() {
 			It("shouldn't scale beyond max number of workers", func() {
 				By("Deploying workload with replicas = max+4")
-				Expect(driver.deployWorkload(int32(maxNodes+4), scaleUpWorkload)).To(BeNil())
+				Expect(driver.deployWorkload(int32(maxNodes+4), scaleUpWorkload, false)).To(BeNil())
 				By("Validating Scale up")
 				Eventually(
 					driver.targetCluster.getNumberOfReadyNodes,
@@ -216,10 +218,10 @@ func (driver *Driver) controllerTests() {
 				_, latestNode, err := driver.getOldestAndLatestNode()
 				Expect(err).To(BeNil())
 
-				driver.makeNodeUnschedulable(latestNode)
+				driver.addTaintsToNode(latestNode, map[string]bool{disabledTaint: true})
 
 				By("Increasing the workload")
-				Expect(driver.deploySmallWorkload(1, scaleUpWorkload)).To(BeNil())
+				Expect(driver.deploySmallWorkload(1, scaleUpWorkload, true)).To(BeNil())
 
 				By("Validating Scale up")
 				Eventually(
@@ -233,7 +235,7 @@ func (driver *Driver) controllerTests() {
 
 				oldestNode, _, err := driver.getOldestAndLatestNode()
 				Expect(err).To(BeNil())
-				driver.makeNodeSchedulable(oldestNode, false)
+				driver.removeTaintsFromNode(oldestNode, false, map[string]bool{disabledTaint: true})
 
 				By("Validating Scale down")
 				Eventually(
@@ -326,7 +328,7 @@ func (driver *Driver) controllerTests() {
 		Context("create a pod requiring more resources than a single machine can provide", func() {
 			It("shouldn't scale up and log the error", func() {
 				By("Deploying the workload")
-				Expect(driver.deployLargeWorkload(1, scaleUpWorkload)).To(BeNil())
+				Expect(driver.deployLargeWorkload(1, scaleUpWorkload, false)).To(BeNil())
 				By("checking that scale up didn't trigger because of no machine satisfying the requirement")
 				skippedRegexp, _ := regexp.Compile("Pod large-scale-up-pod-.* can't be scheduled on .*, predicate checking error: Insufficient cpu; predicateName=NodeResourcesFit; reasons: Insufficient cpu;")
 				Eventually(func() bool {

--- a/cluster-autoscaler/integration/usage.md
+++ b/cluster-autoscaler/integration/usage.md
@@ -3,11 +3,12 @@
 
 1. No user workload to be deployed other than system-components.
 2. All system-components to be able to run on one node
-3. 3 machinedeployments/node groups in the cluster should be present, with following min:max limits
+3. Ideal machine size -> 2 cores CPU, 8Gi memory
+4. 3 machinedeployments/node groups in the cluster should be present, with following min:max limits
     - machineDeployment1 (1:2)
     - machineDeployment2 (0:1)
     - machineDeployment3 (0:1)
-4. Make sure to **disable** calico-typha pods as they interfere with Integration test (especially ones related to scale-down due to under-utilization). Refer this [doc](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage-as-end-user.md#example-networkingconfig-manifest) to disable it. 
+5. Make sure to **disable** calico-typha pods as they interfere with Integration test (especially ones related to scale-down due to under-utilization). Refer this [doc](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage-as-end-user.md#example-networkingconfig-manifest) to disable it. 
 
 ## Cluster Autoscaler integration test suite
 

--- a/cluster-autoscaler/integration/usage.md
+++ b/cluster-autoscaler/integration/usage.md
@@ -1,12 +1,13 @@
 ## Prerequisite
-(Note the prerequisite will be made less restrictive with time)
+(Note the prerequisite will be made less restrictive with time.)
 
 1. No user workload to be deployed other than system-components.
 2. All system-components to be able to run on one node
 3. 3 machinedeployments/node groups in the cluster should be present, with following min:max limits
-	- machineDeployment1 (1:2)
-	- machineDeployment2 (0:1)
-	- machineDeployment3 (0:1)
+    - machineDeployment1 (1:2)
+    - machineDeployment2 (0:1)
+    - machineDeployment3 (0:1)
+4. Make sure to **disable** calico-typha pods as they interfere with Integration test (especially ones related to scale-down due to under-utilization). Refer this [doc](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage-as-end-user.md#example-networkingconfig-manifest) to disable it. 
 
 ## Cluster Autoscaler integration test suite
 
@@ -14,7 +15,8 @@ Cluster Autoscaler integration test suite runs a set of tests against an actual 
 
 1. Reconfigure the nodeGroups so that the test suite begins with only one nodeGroup, with 3 zones and 1 node running
 2. CA would run with leader-election= false
-2. The testcases will deploy and remove the workloads and nodes based on the test scenario
+3. The testcases will deploy and remove the workloads and nodes based on the test scenario. 
+4. During the tests any nodes present before the start of test suite is tainted with taint  having key `testing.node.gardener.cloud/initial-node-blocked`. This taint is removed after the test suite is done (succeeded or failed)
 
 ## Usage guide for running Cluster Autoscaler integration test suite
 
@@ -95,7 +97,7 @@ Cluster Autoscaler integration test suite runs a set of tests against an actual 
 5. Should not scale lower than the min limit for the nodegrp
 6. Should scale up on the basis of taints and not only on workload size.
 7. Should respond by shifting load if some taint is removed from a workload/node.
-8. AutoScaler scales up a node in zone where PV already present and pod is requesting that PV. CSI PV is used.
+8. Autoscaler scales up a node in zone where PV already present and pod is requesting that PV. CSI PV is used.
 9. Should not scale down a node with  annotation "cluster-autoscaler.kubernetes.io/scale-down-disabled": "true"
 10. Should scale down a node after the above annotation is removed from it.
 11. Should not scale if no machine in worker group can satisfy the requirements of the pod.
@@ -124,12 +126,12 @@ Cluster Autoscaler integration test suite runs a set of tests against an actual 
 20. Should be able to scale a node group down to 0
 21. Shouldn't perform scale up operation and should list unhealthy status if most of the cluster is broken
 22. shouldn't scale up when expendable pod is created 
-23. should scale up when non expendable pod is created
+23. should scale up when non-expandable pod is created
 24. shouldn't scale up when expendable pod is preempted
 25. should scale down when expendable pod is running 
-26. shouldn't scale down when non expendable pod is running
+26. shouldn't scale down when non-expandable pod is running
 
-### test for GPU Pool
+### Tests for GPU Pool
 
 1. Should scale up GPU pool from 0
 2. Should scale up GPU pool from 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Integration Tests have been updated.

Updates:

* Taint is added to any node present before the test suite starts and after the test suite finishes (successfully or unsuccessfully)
* `--ignore-taint` flag has been updated in Makefile, for `make start` makerule.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Nodes present in the cluster prior to IT would now be tainted with taint `testing.node.gardener.cloud/initial-node-blocked`. This taint is removed once IT finishes (pass or fail)
```
