### PR TITLE
Cherry pick upstream pr 5246 on 1.24

### DIFF
--- a/cluster-autoscaler/Makefile
+++ b/cluster-autoscaler/Makefile
@@ -9,6 +9,7 @@ GOOS?=linux
 GOARCH?=$(shell go env GOARCH)
 REGISTRY?=staging-k8s.gcr.io
 DOCKER_NETWORK?=default
+LEADER_ELECT?=false
 ifdef BUILD_TAGS
   TAGS_FLAG=--tags ${BUILD_TAGS}
   PROVIDER=-${BUILD_TAGS}

--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -123,7 +123,7 @@ func (p *priority) BestOptions(expansionOptions []expander.Option, nodeInfo map[
 
 	priorities, cm, err := p.reloadConfigMap()
 	if err != nil {
-		return nil
+		return expansionOptions
 	}
 
 	maxPrio := -1

--- a/cluster-autoscaler/expander/priority/priority.go
+++ b/cluster-autoscaler/expander/priority/priority.go
@@ -61,7 +61,10 @@ func NewFilter(configMapLister v1lister.ConfigMapNamespaceLister,
 func (p *priority) reloadConfigMap() (priorities, *apiv1.ConfigMap, error) {
 	cm, err := p.configMapLister.Get(PriorityConfigMapName)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Priority expander config map %s not found: %v", PriorityConfigMapName, err)
+		// FORK-CHANGE: logged warning to simplify debugging.
+		msg := fmt.Sprintf("Priority expander config map %q not found: %v", PriorityConfigMapName, err)
+		klog.Warning(msg)
+		return nil, nil, errors.New(msg)
 	}
 
 	prioString, found := cm.Data[ConfigMapKey]


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
If priority expander specified, but config map not deployed in `kube-system` namespace of shoot , then warning log in autoscaler logs printed.
```
