### PR TITLE
Change default values for fields in `NodeGroupDifferenceRatios`

### DIFF
--- a/cluster-autoscaler/config/autoscaling_options.go
+++ b/cluster-autoscaler/config/autoscaling_options.go
@@ -60,11 +60,19 @@ type GCEOptions struct {
 
 const (
 	// DefaultMaxAllocatableDifferenceRatio describes how Node.Status.Allocatable can differ between groups in the same NodeGroupSet
-	DefaultMaxAllocatableDifferenceRatio = 0.05
+	// FORK-CHANGE: changing to 50% or any very high %age as gardener nodegroups have similar node group label and so
+	// comparison won't be done with any other nodegroup node, done to help in balancing during scale from zero
+	DefaultMaxAllocatableDifferenceRatio = 0.5
 	// DefaultMaxFreeDifferenceRatio describes how free resources (allocatable - daemon and system pods)
-	DefaultMaxFreeDifferenceRatio = 0.05
-	// DefaultMaxCapacityMemoryDifferenceRatio describes how Node.Status.Capacity.Memory
-	DefaultMaxCapacityMemoryDifferenceRatio = 0.015
+	// can differ between groups in the same NodeGroupSet
+	// FORK-CHANGE: changing to 50% or any very high %age as gardener nodegroups have similar node group label and so
+	// comparison won't be done with any other nodegroup node, done to help in balancing during scale from zero
+	DefaultMaxFreeDifferenceRatio = 0.5
+	// DefaultMaxCapacityMemoryDifferenceRatio describes how Node.Status.Capacity.Memory can differ between
+	// groups in the same NodeGroupSet
+	// FORK-CHANGE: changing to 50% or any very high %age as gardener nodegroups have similar node group label and so
+	// comparison won't be done with any other nodegroup node, done to help in balancing during scale from zero
+	DefaultMaxCapacityMemoryDifferenceRatio = 0.5
 )
 
 // NodeGroupDifferenceRatios contains various ratios used to determine if two NodeGroups are similar and makes scaling decisions

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -27,21 +27,6 @@ import (
 )
 
 const (
-	// MaxAllocatableDifferenceRatio describes how Node.Status.Allocatable can differ between
-	// groups in the same NodeGroupSet
-	// FORK-CHANGE: changing to 50% or any very high %age as gardener nodegroups have similar node group label and so
-	// comparison won't be done with any other nodegroup node, done to help in balancing during scale from zero
-	MaxAllocatableDifferenceRatio = 0.5
-	// MaxFreeDifferenceRatio describes how free resources (allocatable - daemon and system pods)
-	// can differ between groups in the same NodeGroupSet
-	// FORK-CHANGE: changing to 50% or any very high %age as gardener nodegroups have similar node group label and so
-	// comparison won't be done with any other nodegroup node, done to help in balancing during scale from zero
-	MaxFreeDifferenceRatio = 0.5
-	// MaxCapacityMemoryDifferenceRatio describes how Node.Status.Capacity.Memory can differ between
-	// groups in the same NodeGroupSet
-	// FORK-CHANGE: changing to 50% or any very high %age as gardener nodegroups have similar node group label and so
-	// comparison won't be done with any other nodegroup node, done to help in balancing during scale from zero
-	MaxCapacityMemoryDifferenceRatio = 0.5
 	// LabelWorkerKubernetesVersion is a constant for a label that indicates the kubernetes version of the kubelet on the node
 	LabelWorkerKubernetesVersion = "worker.gardener.cloud/kubernetes-version"
 	// LabelWorkerPool is a constant for a label that indicates the worker pool the node belongs to


### PR DESCRIPTION
**What this PR does / why we need it**:
Change default values for `NodeGroupDifferenceRatios` to be consistent with the changes introduced in #114.

**Which issue(s) this PR fixes**:
Fixes #226 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
