### PR TITLE
Add separate worker pool for system components in `IT`, fix `kubeconfig` download script.

### DIFF
--- a/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
+++ b/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go
@@ -139,7 +139,8 @@ func (o *ScaleUpOrchestrator) ScaleUp(
 			continue
 		}
 		if currentTargetSize >= nodeGroup.MaxSize() {
-			klog.V(4).Infof("Skipping node group %s - max size reached", nodeGroup.Id())
+			//FORK-CHANGE: log level changed to 2 for better debugging.
+			klog.V(2).Infof("Skipping node group %s - max size reached", nodeGroup.Id())
 			skippedNodeGroups[nodeGroup.Id()] = MaxLimitReachedReason
 			continue
 		}

--- a/cluster-autoscaler/hack/kubeconfig-request.json
+++ b/cluster-autoscaler/hack/kubeconfig-request.json
@@ -1,0 +1,7 @@
+{
+  "apiVersion": "authentication.gardener.cloud/v1alpha1",
+  "kind": "AdminKubeconfigRequest",
+  "spec": {
+    "expirationSeconds": 3600
+  }
+}

--- a/cluster-autoscaler/hack/local_setup.sh
+++ b/cluster-autoscaler/hack/local_setup.sh
@@ -40,24 +40,21 @@ done
 CURRENT_DIR=$(pwd)
 PROJECT_ROOT="${CURRENT_DIR}"
 KUBECONFIG_PATH=$PROJECT_ROOT/dev/kubeconfigs
+NAMESPACE=garden-${PROJECT}
+GARDEN_NAMESPACE=garden
 
-#setting kuebconfig of control cluster
+# target garden cluster
 
-gardenctl target --garden sap-landscape-dev --project garden
-
+gardenctl target --garden sap-landscape-dev
 eval $(gardenctl kubectl-env bash)
 
-echo "$(kubectl get secret/$SEED.kubeconfig --template={{.data.kubeconfig}} | base64 -d)" > $KUBECONFIG_PATH/kubeconfig_control.yaml
+#setting kubeconfig of control cluster
 
-#setting up the target config
+echo "$(kubectl create -f $PROJECT_ROOT/hack/kubeconfig-request.json --raw /apis/core.gardener.cloud/v1beta1/namespaces/${GARDEN_NAMESPACE}/shoots/${SEED}/adminkubeconfig | jq -r ".status.kubeconfig" | base64 -d)" >  $KUBECONFIG_PATH/kubeconfig_control.yaml
 
-gardenctl target --garden sap-landscape-dev --project $PROJECT --shoot $SHOOT --control-plane
+#setting kubeconfig of target cluster
 
-eval $(gardenctl kubectl-env bash)
-
-SECRET=$(kubectl get secrets | awk '{ print $1 }' |grep user-kubeconfig-)
-
-echo "$(kubectl get secret/$SECRET -n shoot--$PROJECT--$SHOOT --template={{.data.kubeconfig}} | base64 -d)" > $KUBECONFIG_PATH/kubeconfig_target.yaml
+echo "$(kubectl create -f $PROJECT_ROOT/hack/kubeconfig-request.json --raw /apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT}/adminkubeconfig | jq -r ".status.kubeconfig" | base64 -d)" >  $KUBECONFIG_PATH/kubeconfig_target.yaml
 
 # All the kubeconfigs are at place
 

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -86,7 +86,7 @@ func (driver *Driver) cleanup() {
 	driver.removeTaintsFromInitialNodes()
 
 	By("Scaling CA back up to 1 in the Shoot namespace")
-	err := driver.scaleAutoscaler(int32(initialNumberOfNodes))
+	err := driver.scaleAutoscaler(int32(1))
 	if err != nil {
 		fmt.Printf("error scaling up cluster autoscaler deployment in control cluster Shoot namespace: %s", err.Error())
 	}

--- a/cluster-autoscaler/integration/usage.md
+++ b/cluster-autoscaler/integration/usage.md
@@ -2,14 +2,15 @@
 (Note the prerequisite will be made less restrictive with time.)
 
 1. No user workload to be deployed other than system-components.
-2. All system-components to be able to run on one node
-3. Required machine size -> 2 cores CPU, 8Gi memory
-4. 2 worker pools are needed named `one-zone` and `three-zones` respectively. The 4 machinedeployments/node groups in the cluster should be present, with following `min:max` limits
+2. 1 worker pool for system components named `sys-comp` with `allowSystemComponents` set to `true` and `min=1`, `max>=2`.
+3. Required machine size -> 2 cores CPU, 8Gi memory 
+4. 2 worker pools are needed namely `one-zone` and `three-zones` respectively with `allowSystemComponents` set to `false`. The 4 machinedeployments/node groups in the cluster should be present, with following `min:max` limits
     - machineDeployment1 (`0:2`) [worker:- `one-zone`]
     - machineDeployment2 (`1:2`) [worker:- `three-zones`]
     - machineDeployment3 (`0:1`) [worker:- `three-zones`]
     - machineDeployment4 (`0:1`) [worker:- `three-zones`]
-5. Make sure to **disable** calico-typha pods as they interfere with Integration test (especially ones related to scale-down due to under-utilization). Refer this [doc](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage-as-end-user.md#example-networkingconfig-manifest) to disable it. 
+5. Make sure that the names of the worker pools are as mentioned above. It is very important for the integration tests to run properly.
+6. Make sure to **disable** calico-typha pods as they interfere with Integration test (especially ones related to scale-down due to under-utilization). Refer this [doc](https://github.com/gardener/gardener-extension-networking-calico/blob/master/docs/usage-as-end-user.md#example-networkingconfig-manifest) to disable it. 
 
 ## Cluster Autoscaler integration test suite
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the initial requirements of the worker pools config for integration tests. There will be a separate worker pool for system components to run on so that they don't interfere with the integration tests. This PR also fixes the kubeconfig download script to generate a temporary kubeconfig to run the tests (See https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md) instead of using the static kubeconfig (support removed in k8s 1.27).  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
