### PR TITLE
Suspend `CA` activities if `MCM` is offline

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/client_builder.go
+++ b/cluster-autoscaler/cloudprovider/mcm/client_builder.go
@@ -20,37 +20,26 @@ https://github.com/kubernetes/kubernetes/blob/release-1.8/pkg/controller/client_
 package mcm
 
 import (
-	clientgoclientset "k8s.io/client-go/kubernetes"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 
 	"k8s.io/klog/v2"
 )
 
-// CoreClientBuilder allows you to get clients and configs for core controllers
-type CoreClientBuilder interface {
-	Config(name string) (*restclient.Config, error)
-	ConfigOrDie(name string) *restclient.Config
-	Client(name string) (clientset.Interface, error)
-	ClientOrDie(name string) clientset.Interface
-	ClientGoClient(name string) (clientgoclientset.Interface, error)
-	ClientGoClientOrDie(name string) clientgoclientset.Interface
-}
-
-// CoreControllerClientBuilder returns a fixed client with different user agents
-type CoreControllerClientBuilder struct {
+// ClientBuilder returns a fixed client with different user agents
+type ClientBuilder struct {
 	// ClientConfig is a skeleton config to clone and use as the basis for each controller client
 	ClientConfig *restclient.Config
 }
 
 // Config lets you configure the client builder
-func (b CoreControllerClientBuilder) Config(name string) (*restclient.Config, error) {
+func (b ClientBuilder) Config(name string) (*restclient.Config, error) {
 	clientConfig := *b.ClientConfig
 	return restclient.AddUserAgent(&clientConfig, name), nil
 }
 
 // ConfigOrDie either configures or die's while configuring
-func (b CoreControllerClientBuilder) ConfigOrDie(name string) *restclient.Config {
+func (b ClientBuilder) ConfigOrDie(name string) *restclient.Config {
 	clientConfig, err := b.Config(name)
 	if err != nil {
 		klog.Fatal(err)
@@ -59,7 +48,7 @@ func (b CoreControllerClientBuilder) ConfigOrDie(name string) *restclient.Config
 }
 
 // Client builds a new client for clientBuilder
-func (b CoreControllerClientBuilder) Client(name string) (clientset.Interface, error) {
+func (b ClientBuilder) Client(name string) (clientset.Interface, error) {
 	clientConfig, err := b.Config(name)
 	if err != nil {
 		return nil, err
@@ -68,26 +57,8 @@ func (b CoreControllerClientBuilder) Client(name string) (clientset.Interface, e
 }
 
 // ClientOrDie builds a client or die's
-func (b CoreControllerClientBuilder) ClientOrDie(name string) clientset.Interface {
+func (b ClientBuilder) ClientOrDie(name string) clientset.Interface {
 	client, err := b.Client(name)
-	if err != nil {
-		klog.Fatal(err)
-	}
-	return client
-}
-
-// ClientGoClient builds a go client
-func (b CoreControllerClientBuilder) ClientGoClient(name string) (clientgoclientset.Interface, error) {
-	clientConfig, err := b.Config(name)
-	if err != nil {
-		return nil, err
-	}
-	return clientgoclientset.NewForConfig(clientConfig)
-}
-
-// ClientGoClientOrDie builds a go client or die's
-func (b CoreControllerClientBuilder) ClientGoClientOrDie(name string) clientgoclientset.Interface {
-	client, err := b.ClientGoClient(name)
 	if err != nil {
 		klog.Fatal(err)
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/fakeclient/client.go
+++ b/cluster-autoscaler/cloudprovider/mcm/fakeclient/client.go
@@ -484,11 +484,11 @@ func NewCoreClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker
 	return cs, o
 }
 
-// NewAppsV1ClientSet returns a clientset that will respond with the provided objects.
+// NewAppsClientSet returns a clientset that will respond with the provided objects.
 // It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
 // without applying any validations and/or defaults. It shouldn't be considered a replacement
 // for a real clientset and is mostly useful in simple unit tests.
-func NewAppsV1ClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker) {
+func NewAppsClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker) {
 
 	var scheme = runtime.NewScheme()
 	var codecs = serializer.NewCodecFactory(scheme)

--- a/cluster-autoscaler/cloudprovider/mcm/fakeclient/client.go
+++ b/cluster-autoscaler/cloudprovider/mcm/fakeclient/client.go
@@ -484,6 +484,10 @@ func NewCoreClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker
 	return cs, o
 }
 
+// NewAppsV1ClientSet returns a clientset that will respond with the provided objects.
+// It's backed by a very simple object tracker that processes creates, updates and deletions as-is,
+// without applying any validations and/or defaults. It shouldn't be considered a replacement
+// for a real clientset and is mostly useful in simple unit tests.
 func NewAppsV1ClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker) {
 
 	var scheme = runtime.NewScheme()

--- a/cluster-autoscaler/cloudprovider/mcm/fakeclient/client.go
+++ b/cluster-autoscaler/cloudprovider/mcm/fakeclient/client.go
@@ -415,15 +415,16 @@ func NewMachineClientSet(objects ...runtime.Object) (*fakeuntyped.Clientset, *Fa
 
 // FakeObjectTrackers is a struct containing all the controller fake object trackers
 type FakeObjectTrackers struct {
-	ControlMachine, TargetCore *FakeObjectTracker
+	ControlMachine, TargetCore, ControlApps *FakeObjectTracker
 }
 
 // NewFakeObjectTrackers initializes fakeObjectTrackers initializes the fake object trackers
-func NewFakeObjectTrackers(controlMachine, targetCore *FakeObjectTracker) *FakeObjectTrackers {
+func NewFakeObjectTrackers(controlMachine, targetCore, controlApps *FakeObjectTracker) *FakeObjectTrackers {
 
 	fakeObjectTrackers := &FakeObjectTrackers{
 		ControlMachine: controlMachine,
 		TargetCore:     targetCore,
+		ControlApps:    controlApps,
 	}
 
 	return fakeObjectTrackers
@@ -462,6 +463,33 @@ func NewCoreClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker
 	var codecs = serializer.NewCodecFactory(scheme)
 
 	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
+	_ = k8sfake.AddToScheme(scheme)
+
+	o := &FakeObjectTracker{
+		FakeWatcher: watch.NewFake(),
+		delegatee:   k8stesting.NewObjectTracker(scheme, codecs.UniversalDecoder()),
+	}
+
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &Clientset{Clientset: &k8sfake.Clientset{}}
+	cs.FakeDiscovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.Fake.AddReactor("*", "*", k8stesting.ObjectReaction(o))
+	cs.Fake.AddWatchReactor("*", o.watchReactionFunc)
+
+	return cs, o
+}
+
+func NewAppsV1ClientSet(objects ...runtime.Object) (*Clientset, *FakeObjectTracker) {
+
+	var scheme = runtime.NewScheme()
+	var codecs = serializer.NewCodecFactory(scheme)
+
+	metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1", Group: "apps"})
 	_ = k8sfake.AddToScheme(scheme)
 
 	o := &FakeObjectTracker{

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -190,7 +190,6 @@ func (mcm *mcmCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimite
 	return mcm.resourceLimiter, nil
 }
 
-// checkMCMAvailableReplicas checks if mcm is online
 func (mcm *mcmCloudProvider) checkMCMAvailableReplicas() error {
 	namespace := mcm.mcmManager.namespace
 	deployment, err := mcm.mcmManager.deploymentLister.Deployments(namespace).Get("machine-controller-manager")

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -24,19 +24,26 @@ package mcm
 import (
 	"context"
 	"fmt"
-	"strings"
-
+	v1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	kube_client "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
+	"os"
+	"strings"
+	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/config/dynamic"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	v1appslister "k8s.io/client-go/listers/apps/v1"
 )
 
 const (
@@ -47,6 +54,8 @@ const (
 	// TODO: Align on a GPU Label for Gardener.
 	GPULabel = "gardener.cloud/accelerator"
 )
+
+var DeployKubeClient kube_client.Interface
 
 // MCMCloudProvider implements the cloud provider interface for machine-controller-manager
 // Reference: https://github.com/gardener/machine-controller-manager
@@ -192,9 +201,48 @@ func (mcm *mcmCloudProvider) GetResourceLimiter() (*cloudprovider.ResourceLimite
 	return mcm.resourceLimiter, nil
 }
 
+var deploymentLister *v1appslister.DeploymentLister
+
+func init() {
+	deploymentLister = newDeploymentLister()
+}
+
+func newDeploymentLister() *v1appslister.DeploymentLister {
+	namespace := os.Getenv("CONTROL_NAMESPACE")
+	controlKubeconfig, err := clientcmd.BuildConfigFromFlags("", "")
+	if err != nil {
+		klog.Errorf(err.Error())
+	}
+	controlCoreClientBuilder := CoreControllerClientBuilder{
+		ClientConfig: controlKubeconfig,
+	}
+	DeployKubeClient = controlCoreClientBuilder.ClientOrDie("deploykubeclient")
+	selector := fields.Everything()
+	deploymentListWatch := cache.NewListWatchFromClient(DeployKubeClient.AppsV1().RESTClient(), "deployments", namespace, selector)
+	store, reflector := cache.NewNamespaceKeyedIndexerAndReflector(deploymentListWatch, &v1.Deployment{}, time.Hour)
+	deploymentLister := v1appslister.NewDeploymentLister(store)
+	stopCh := make(chan struct{})
+	go reflector.Run(stopCh)
+	return &deploymentLister
+}
+
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 func (mcm *mcmCloudProvider) Refresh() error {
+
+	lister := deploymentLister
+	namespace := os.Getenv("CONTROL_NAMESPACE")
+	deployment, err := (*lister).Deployments(namespace).Get("machine-controller-manager")
+	if err != nil {
+		klog.Errorf("failed to get machine-controller-manager deployment: ", err.Error())
+		return err
+	}
+
+	if !(deployment.Status.AvailableReplicas >= 1) {
+		klog.Errorf("machine-controller-manager is offline. Cluster autoscaler operations would be suspended.")
+		return err
+	}
+
 	for _, machineDeployment := range mcm.machinedeployments {
 		err := mcm.mcmManager.resetPriorityForNotToBeDeletedMachines(machineDeployment.Name)
 		if err != nil {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -197,7 +197,7 @@ func (mcm *mcmCloudProvider) checkMCMAvailableReplicas() error {
 		return fmt.Errorf("failed to get machine-controller-manager deployment: %v", err.Error())
 	}
 
-	if !(deployment.Status.AvailableReplicas >= 1) {
+	if deployment.Status.AvailableReplicas == 0 {
 		return fmt.Errorf("machine-controller-manager is offline. Cluster autoscaler operations would be suspended.")
 	}
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -197,13 +197,11 @@ func (mcm *mcmCloudProvider) Refresh() error {
 	namespace := mcm.mcmManager.namespace
 	deployment, err := mcm.mcmManager.deploymentLister.Deployments(namespace).Get("machine-controller-manager")
 	if err != nil {
-		klog.Errorf("failed to get machine-controller-manager deployment: %v", err.Error())
-		return err
+		return fmt.Errorf("failed to get machine-controller-manager deployment: %v", err.Error())
 	}
 
 	if !(deployment.Status.AvailableReplicas >= 1) {
-		klog.Errorf("machine-controller-manager is offline. Cluster autoscaler operations would be suspended.")
-		return errors.NewAutoscalerError(errors.CloudProviderError, "machine-controller-manager is offline. Cluster autoscaler operations would be suspended.")
+		return fmt.Errorf("machine-controller-manager is offline. Cluster autoscaler operations would be suspended.")
 	}
 
 	for _, machineDeployment := range mcm.machinedeployments {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -52,7 +52,7 @@ type setup struct {
 	machines                          []*v1alpha1.Machine
 	machineSets                       []*v1alpha1.MachineSet
 	machineDeployments                []*v1alpha1.MachineDeployment
-	deployments                       *v1.Deployment
+	mcmDeployment                     *v1.Deployment
 	machineClasses                    []*v1alpha1.MachineClass
 	nodeGroups                        []string
 	targetCoreFakeResourceActions     *customfake.ResourceActions
@@ -82,8 +82,8 @@ func setupEnv(setup *setup) ([]runtime.Object, []runtime.Object, []runtime.Objec
 
 	var appsControlObjects []runtime.Object
 
-	if setup.deployments != nil {
-		appsControlObjects = append(appsControlObjects, setup.deployments)
+	if setup.mcmDeployment != nil {
+		appsControlObjects = append(appsControlObjects, setup.mcmDeployment)
 	}
 
 	return controlMachineObjects, targetCoreObjects, appsControlObjects
@@ -356,7 +356,7 @@ func TestRefresh(t *testing.T) {
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
-				deployments:        newMCMDeployment(0),
+				mcmDeployment:      newMCMDeployment(0),
 			},
 			expect{
 				err: fmt.Errorf("machine-controller-manager is offline. Cluster autoscaler operations would be suspended."),
@@ -383,7 +383,7 @@ func TestRefresh(t *testing.T) {
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
-				deployments:        newMCMDeployment(1),
+				mcmDeployment:      newMCMDeployment(1),
 			},
 			expect{
 				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
@@ -397,7 +397,7 @@ func TestRefresh(t *testing.T) {
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
-				deployments:        newMCMDeployment(1),
+				mcmDeployment:      newMCMDeployment(1),
 			},
 			expect{
 				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
@@ -415,8 +415,8 @@ func TestRefresh(t *testing.T) {
 						Update: customfake.CreateFakeResponse(math.MaxInt32, mcUpdateErrorMsg, 0),
 					},
 				},
-				nodeGroups:  []string{nodeGroup2},
-				deployments: newMCMDeployment(1),
+				nodeGroups:    []string{nodeGroup2},
+				mcmDeployment: newMCMDeployment(1),
 			},
 			expect{
 				machines: []*v1alpha1.Machine{newMachine("machine-1", "fakeID-1", nil, "machinedeployment-1", "machineset-1", "1", false, true)},

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -364,7 +364,7 @@ func TestRefresh(t *testing.T) {
 		},
 		{
 
-			"should  return an error if MCM deployment is not found",
+			"should return an error if MCM deployment is not found",
 			setup{
 				nodes:              newNodes(1, "fakeID", []bool{false}),
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -350,7 +350,7 @@ func TestRefresh(t *testing.T) {
 	table := []data{
 		{
 
-			"should set available replicas of mcm as zero",
+			"should return an error if MCM has zero available replicas",
 			setup{
 				nodes:              newNodes(1, "fakeID", []bool{false}),
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
@@ -364,7 +364,7 @@ func TestRefresh(t *testing.T) {
 		},
 		{
 
-			"should get no deployment of mcm",
+			"should  return an error if MCM deployment is not found",
 			setup{
 				nodes:              newNodes(1, "fakeID", []bool{false}),
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -181,7 +181,7 @@ func createMCMManagerInternal(discoveryOpts cloudprovider.NodeGroupDiscoveryOpti
 
 	controlAppsClient := controlClientBuilder.ClientOrDie("control-apps-client")
 	selector := fields.Everything()
-	deploymentListWatch := cache.NewListWatchFromClient(controlAppsClient.AppsV1().RESTClient(), "deployments", namespace, selector)
+	deploymentListWatch := cache.NewListWatchFromClient(controlAppsClient.AppsV1().RESTClient(), "mcmDeployment", namespace, selector)
 	store, reflector := cache.NewNamespaceKeyedIndexerAndReflector(deploymentListWatch, &appsv1.Deployment{}, time.Hour)
 	deploymentLister := v1appslister.NewDeploymentLister(store)
 	stopCh := make(chan struct{})

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -18,6 +18,8 @@ package mcm
 
 import (
 	"fmt"
+	v1 "k8s.io/api/apps/v1"
+	"k8s.io/utils/pointer"
 	"testing"
 	"time"
 
@@ -35,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	customfake "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mcm/fakeclient"
 	deletetaint "k8s.io/autoscaler/cluster-autoscaler/utils/taints"
+	appsv1informers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers"
 )
 
@@ -220,11 +223,28 @@ func newMachineStatus(statusTemplate *v1alpha1.MachineStatus) *v1alpha1.MachineS
 	return statusTemplate.DeepCopy()
 }
 
+func newDeployments(availableReplicas int32) []*v1.Deployment {
+	return []*v1.Deployment{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "machine-controller-manager",
+				Namespace: testNamespace,
+			},
+			Spec: v1.DeploymentSpec{
+				Replicas: pointer.Int32(1),
+			},
+			Status: v1.DeploymentStatus{
+				AvailableReplicas: availableReplicas,
+			},
+		},
+	}
+}
+
 func createMcmManager(
 	t *testing.T,
 	stop <-chan struct{},
 	namespace string,
-	nodeGroups []string, controlMachineObjects, targetCoreObjects []runtime.Object,
+	nodeGroups []string, controlMachineObjects, targetCoreObjects, controlAppsObjects []runtime.Object,
 ) (*McmManager, *customfake.FakeObjectTrackers, []cache.InformerSynced) {
 	g := gomega.NewWithT(t)
 	fakeControlMachineClient, controlMachineObjectTracker := customfake.NewMachineClientSet(controlMachineObjects...)
@@ -232,12 +252,13 @@ func createMcmManager(
 		Fake: &fakeControlMachineClient.Fake,
 	}
 	fakeTargetCoreClient, targetCoreObjectTracker := customfake.NewCoreClientSet(targetCoreObjects...)
+	fakeControlAppsClient, controlAppsObjectTracker := customfake.NewAppsV1ClientSet(controlAppsObjects...)
 	fakeObjectTrackers := customfake.NewFakeObjectTrackers(
 		controlMachineObjectTracker,
 		targetCoreObjectTracker,
+		controlAppsObjectTracker,
 	)
 	fakeObjectTrackers.Start()
-
 	coreTargetInformerFactory := coreinformers.NewFilteredSharedInformerFactory(
 		fakeTargetCoreClient,
 		100*time.Millisecond,
@@ -247,6 +268,15 @@ func createMcmManager(
 	defer coreTargetInformerFactory.Start(stop)
 	coreTargetSharedInformers := coreTargetInformerFactory.Core().V1()
 	nodes := coreTargetSharedInformers.Nodes()
+
+	appsControlInformerFactory := appsv1informers.NewFilteredSharedInformerFactory(
+		fakeControlAppsClient,
+		100*time.Millisecond,
+		namespace,
+		nil,
+	)
+	defer appsControlInformerFactory.Start(stop)
+	appsControlSharedInformers := appsControlInformerFactory.Apps().V1()
 
 	controlMachineInformerFactory := machineinformers.NewFilteredSharedInformerFactory(
 		fakeControlMachineClient,
@@ -272,6 +302,7 @@ func createMcmManager(
 		discoveryOpts: cloudprovider.NodeGroupDiscoveryOptions{
 			NodeGroupSpecs: nodeGroups,
 		},
+		deploymentLister:        appsControlSharedInformers.Deployments().Lister(),
 		machineClient:           fakeTypedMachineClient,
 		machineDeploymentLister: machineDeployments.Lister(),
 		machineSetLister:        machineSets.Lister(),
@@ -288,6 +319,7 @@ func createMcmManager(
 		machineSets.Informer().HasSynced,
 		machineDeployments.Informer().HasSynced,
 		machineClasses.Informer().HasSynced,
+		appsControlSharedInformers.Deployments().Informer().HasSynced,
 	}
 
 	return &mcmManager, fakeObjectTrackers, hasSyncedCachesFns

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -18,7 +18,7 @@ package mcm
 
 import (
 	"fmt"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/utils/pointer"
 	"testing"
 	"time"
@@ -198,7 +198,7 @@ func newNodes(
 		}
 		node := &corev1.Node{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
+				APIVersion: "appsv1",
 				Kind:       "Node",
 			},
 			ObjectMeta: metav1.ObjectMeta{
@@ -223,19 +223,17 @@ func newMachineStatus(statusTemplate *v1alpha1.MachineStatus) *v1alpha1.MachineS
 	return statusTemplate.DeepCopy()
 }
 
-func newDeployments(availableReplicas int32) []*v1.Deployment {
-	return []*v1.Deployment{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "machine-controller-manager",
-				Namespace: testNamespace,
-			},
-			Spec: v1.DeploymentSpec{
-				Replicas: pointer.Int32(1),
-			},
-			Status: v1.DeploymentStatus{
-				AvailableReplicas: availableReplicas,
-			},
+func newMCMDeployment(availableReplicas int32) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "machine-controller-manager",
+			Namespace: testNamespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+		},
+		Status: appsv1.DeploymentStatus{
+			AvailableReplicas: availableReplicas,
 		},
 	}
 }
@@ -252,7 +250,7 @@ func createMcmManager(
 		Fake: &fakeControlMachineClient.Fake,
 	}
 	fakeTargetCoreClient, targetCoreObjectTracker := customfake.NewCoreClientSet(targetCoreObjects...)
-	fakeControlAppsClient, controlAppsObjectTracker := customfake.NewAppsV1ClientSet(controlAppsObjects...)
+	fakeControlAppsClient, controlAppsObjectTracker := customfake.NewAppsClientSet(controlAppsObjects...)
 	fakeObjectTrackers := customfake.NewFakeObjectTrackers(
 		controlMachineObjectTracker,
 		targetCoreObjectTracker,

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -395,9 +395,9 @@ func (driver *Driver) controllerTests() {
 				flag = true
 			})
 		})
-	})
+	})git
 	Describe("testing CA behaviour when MCM is offline", func() {
-		Context("When the availble replicas of MCM are zero.", func() {
+		Context("When the available replicas of MCM are zero.", func() {
 			It("The CA should suspend it's operations as long as MCM is offline", func() {
 				By("Scaling down the MCM")
 				deployment, err := driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Get(context.Background(), "machine-controller-manager", metav1.GetOptions{})

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/pointer"
 	"os"
 	"regexp"
 	"strings"
@@ -391,6 +392,31 @@ func (driver *Driver) controllerTests() {
 				Expect(mc.Annotations[mcmPriorityAnnotation]).To(Equal("3"))
 
 				// For AfterCheck function to clean up the workload, set flag as true
+				flag = true
+			})
+		})
+	})
+	Describe("testing CA behaviour when MCM is offline", func() {
+		Context("When the availble replicas of MCM are zero.", func() {
+			It("The CA should suspend it's operations as long as MCM is offline", func() {
+				By("Scaling down the MCM")
+				deployment, err := driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Get(context.Background(), "machine-controller-manager", metav1.GetOptions{})
+				Expect(err).Should(BeNil())
+				deployment.Spec.Replicas = pointer.Int32(0)
+				deployment.ObjectMeta.Annotations[dwdAnnotation] = "true"
+				_, err = driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Update(context.Background(), deployment, metav1.UpdateOptions{})
+				Expect(err).Should(BeNil())
+				skippedRegexp, _ := regexp.Compile("machine-controller-manager is offline. Cluster autoscaler operations would be suspended.")
+				Eventually(func() bool {
+					data, _ := ioutil.ReadFile(CALogFile)
+					return skippedRegexp.Match(data)
+				}, pollingTimeout, pollingInterval).Should(BeTrue())
+				deployment, err = driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Get(context.Background(), "machine-controller-manager", metav1.GetOptions{})
+				Expect(err).Should(BeNil())
+				deployment.Spec.Replicas = pointer.Int32(1)
+				delete(deployment.ObjectMeta.Annotations, dwdAnnotation)
+				_, err = driver.controlCluster.Clientset.AppsV1().Deployments(controlClusterNamespace).Update(context.Background(), deployment, metav1.UpdateOptions{})
+				Expect(err).Should(BeNil())
 				flag = true
 			})
 		})

--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -395,7 +395,7 @@ func (driver *Driver) controllerTests() {
 				flag = true
 			})
 		})
-	})git
+	})
 	Describe("testing CA behaviour when MCM is offline", func() {
 		Context("When the available replicas of MCM are zero.", func() {
 			It("The CA should suspend it's operations as long as MCM is offline", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR modifies the `Refresh` method of CA to suspend CA if MCM is offline.
**Which issue(s) this PR fixes**:
Fixes #60 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cluster Autoscaler will suspend its activities if the machine-controller-manager is offline
```
