### PR TITLE
Add options to `NodeGroupAutoscalingOptions` from `machineDeployment` annotations

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -24,6 +24,10 @@ package mcm
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/labels"
@@ -34,7 +38,6 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog/v2"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework"
-	"strings"
 )
 
 const (
@@ -44,6 +47,21 @@ const (
 	// GPULabel is the label added to nodes with GPU resource.
 	// TODO: Align on a GPU Label for Gardener.
 	GPULabel = "gardener.cloud/accelerator"
+
+	// ScaleDownUtilizationThresholdAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.ScaleDownUtilizationThreshold
+	ScaleDownUtilizationThresholdAnnotation = "autoscaler.gardener.cloud/scale-down-utilization-threshold"
+
+	// ScaleDownGpuUtilizationThresholdAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.ScaleDownGpuUtilizationThreshold
+	ScaleDownGpuUtilizationThresholdAnnotation = "autoscaler.gardener.cloud/scale-down-gpu-utilization-threshold"
+
+	// ScaleDownUnneededTimeAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.ScaleDownUnneededTime
+	ScaleDownUnneededTimeAnnotation = "autoscaler.gardener.cloud/scale-down-unneeded-time"
+
+	// ScaleDownUnreadyTimeAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.ScaleDownUnreadyTime
+	ScaleDownUnreadyTimeAnnotation = "autoscaler.gardener.cloud/scale-down-unready-time"
+
+	// MaxNodeProvisionTimeAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.MaxNodeProvisionTime
+	MaxNodeProvisionTimeAnnotation = "autoscaler.gardener.cloud/max-node-provision-time"
 )
 
 // MCMCloudProvider implements the cloud provider interface for machine-controller-manager
@@ -441,7 +459,51 @@ func (machinedeployment *MachineDeployment) Nodes() ([]cloudprovider.Instance, e
 // Implementation optional.
 // TODO: add proper implementation
 func (machinedeployment *MachineDeployment) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	return nil, cloudprovider.ErrNotImplemented
+	mcdSpec, err := machinedeployment.mcmManager.GetMachineDeploymentSpec(machinedeployment.Name)
+	if err != nil {
+		return nil, err
+	}
+	if mcdSpec == nil {
+		return nil, fmt.Errorf("nil machinedeployment returned for %s", machinedeployment.Name)
+	}
+
+	scaleDownUtilThresholdValue := defaults.ScaleDownUtilizationThreshold
+	if _, ok := mcdSpec.Annotations[ScaleDownUtilizationThresholdAnnotation]; ok {
+		if floatVal, err := strconv.ParseFloat(mcdSpec.Annotations[ScaleDownUtilizationThresholdAnnotation], 64); err == nil {
+			scaleDownUtilThresholdValue = floatVal
+		}
+	}
+	scaleDownGPUUtilThresholdValue := defaults.ScaleDownGpuUtilizationThreshold
+	if _, ok := mcdSpec.Annotations[ScaleDownGpuUtilizationThresholdAnnotation]; ok {
+		if floatVal, err := strconv.ParseFloat(mcdSpec.Annotations[ScaleDownGpuUtilizationThresholdAnnotation], 64); err == nil {
+			scaleDownGPUUtilThresholdValue = floatVal
+		}
+	}
+	scaleDownUnneededTimeValue := defaults.ScaleDownUnneededTime
+	if _, ok := mcdSpec.Annotations[ScaleDownUnneededTimeAnnotation]; ok {
+		if timeValue, err := time.ParseDuration(mcdSpec.Annotations[ScaleDownUnneededTimeAnnotation]); err == nil {
+			scaleDownUnneededTimeValue = timeValue
+		}
+	}
+	scaleDownUnreadyTimeValue := defaults.ScaleDownUnreadyTime
+	if _, ok := mcdSpec.Annotations[ScaleDownUnreadyTimeAnnotation]; ok {
+		if timeValue, err := time.ParseDuration(mcdSpec.Annotations[ScaleDownUnreadyTimeAnnotation]); err == nil {
+			scaleDownUnreadyTimeValue = timeValue
+		}
+	}
+	maxNodeProvisionTimeValue := defaults.MaxNodeProvisionTime
+	if _, ok := mcdSpec.Annotations[MaxNodeProvisionTimeAnnotation]; ok {
+		if timeValue, err := time.ParseDuration(mcdSpec.Annotations[MaxNodeProvisionTimeAnnotation]); err == nil {
+			maxNodeProvisionTimeValue = timeValue
+		}
+	}
+	return &config.NodeGroupAutoscalingOptions{
+		ScaleDownUtilizationThreshold:    scaleDownUtilThresholdValue,
+		ScaleDownGpuUtilizationThreshold: scaleDownGPUUtilThresholdValue,
+		ScaleDownUnneededTime:            scaleDownUnneededTimeValue,
+		ScaleDownUnreadyTime:             scaleDownUnreadyTimeValue,
+		MaxNodeProvisionTime:             maxNodeProvisionTimeValue,
+	}, nil
 }
 
 // TemplateNodeInfo returns a node template for this node group.

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -457,52 +457,48 @@ func (machinedeployment *MachineDeployment) Nodes() ([]cloudprovider.Instance, e
 // GetOptions returns NodeGroupAutoscalingOptions that should be used for this particular
 // NodeGroup. Returning a nil will result in using default options.
 // Implementation optional.
-// TODO: add proper implementation
 func (machinedeployment *MachineDeployment) GetOptions(defaults config.NodeGroupAutoscalingOptions) (*config.NodeGroupAutoscalingOptions, error) {
-	mcdSpec, err := machinedeployment.mcmManager.GetMachineDeploymentSpec(machinedeployment.Name)
+	mcdAnnotations, err := machinedeployment.mcmManager.GetMachineDeploymentAnnotations(machinedeployment.Name)
 	if err != nil {
 		return nil, err
 	}
-	if mcdSpec == nil {
-		return nil, fmt.Errorf("nil machinedeployment returned for %s", machinedeployment.Name)
-	}
 
 	scaleDownUtilThresholdValue := defaults.ScaleDownUtilizationThreshold
-	if _, ok := mcdSpec.Annotations[ScaleDownUtilizationThresholdAnnotation]; ok {
-		if floatVal, err := strconv.ParseFloat(mcdSpec.Annotations[ScaleDownUtilizationThresholdAnnotation], 64); err == nil {
+	if _, ok := mcdAnnotations[ScaleDownUtilizationThresholdAnnotation]; ok {
+		if floatVal, err := strconv.ParseFloat(mcdAnnotations[ScaleDownUtilizationThresholdAnnotation], 64); err == nil {
 			scaleDownUtilThresholdValue = floatVal
 		}
 	}
 	scaleDownGPUUtilThresholdValue := defaults.ScaleDownGpuUtilizationThreshold
-	if _, ok := mcdSpec.Annotations[ScaleDownGpuUtilizationThresholdAnnotation]; ok {
-		if floatVal, err := strconv.ParseFloat(mcdSpec.Annotations[ScaleDownGpuUtilizationThresholdAnnotation], 64); err == nil {
+	if _, ok := mcdAnnotations[ScaleDownGpuUtilizationThresholdAnnotation]; ok {
+		if floatVal, err := strconv.ParseFloat(mcdAnnotations[ScaleDownGpuUtilizationThresholdAnnotation], 64); err == nil {
 			scaleDownGPUUtilThresholdValue = floatVal
 		}
 	}
-	scaleDownUnneededTimeValue := defaults.ScaleDownUnneededTime
-	if _, ok := mcdSpec.Annotations[ScaleDownUnneededTimeAnnotation]; ok {
-		if timeValue, err := time.ParseDuration(mcdSpec.Annotations[ScaleDownUnneededTimeAnnotation]); err == nil {
-			scaleDownUnneededTimeValue = timeValue
+	scaleDownUnneededDuration := defaults.ScaleDownUnneededTime
+	if _, ok := mcdAnnotations[ScaleDownUnneededTimeAnnotation]; ok {
+		if timeValue, err := time.ParseDuration(mcdAnnotations[ScaleDownUnneededTimeAnnotation]); err == nil {
+			scaleDownUnneededDuration = timeValue
 		}
 	}
-	scaleDownUnreadyTimeValue := defaults.ScaleDownUnreadyTime
-	if _, ok := mcdSpec.Annotations[ScaleDownUnreadyTimeAnnotation]; ok {
-		if timeValue, err := time.ParseDuration(mcdSpec.Annotations[ScaleDownUnreadyTimeAnnotation]); err == nil {
-			scaleDownUnreadyTimeValue = timeValue
+	scaleDownUnreadyDuration := defaults.ScaleDownUnreadyTime
+	if _, ok := mcdAnnotations[ScaleDownUnreadyTimeAnnotation]; ok {
+		if timeValue, err := time.ParseDuration(mcdAnnotations[ScaleDownUnreadyTimeAnnotation]); err == nil {
+			scaleDownUnreadyDuration = timeValue
 		}
 	}
-	maxNodeProvisionTimeValue := defaults.MaxNodeProvisionTime
-	if _, ok := mcdSpec.Annotations[MaxNodeProvisionTimeAnnotation]; ok {
-		if timeValue, err := time.ParseDuration(mcdSpec.Annotations[MaxNodeProvisionTimeAnnotation]); err == nil {
-			maxNodeProvisionTimeValue = timeValue
+	maxNodeProvisionDuration := defaults.MaxNodeProvisionTime
+	if _, ok := mcdAnnotations[MaxNodeProvisionTimeAnnotation]; ok {
+		if timeValue, err := time.ParseDuration(mcdAnnotations[MaxNodeProvisionTimeAnnotation]); err == nil {
+			maxNodeProvisionDuration = timeValue
 		}
 	}
 	return &config.NodeGroupAutoscalingOptions{
 		ScaleDownUtilizationThreshold:    scaleDownUtilThresholdValue,
 		ScaleDownGpuUtilizationThreshold: scaleDownGPUUtilThresholdValue,
-		ScaleDownUnneededTime:            scaleDownUnneededTimeValue,
-		ScaleDownUnreadyTime:             scaleDownUnreadyTimeValue,
-		MaxNodeProvisionTime:             maxNodeProvisionTimeValue,
+		ScaleDownUnneededTime:            scaleDownUnneededDuration,
+		ScaleDownUnreadyTime:             scaleDownUnreadyDuration,
+		MaxNodeProvisionTime:             maxNodeProvisionDuration,
 	}, nil
 }
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -477,20 +477,20 @@ func (machinedeployment *MachineDeployment) GetOptions(defaults config.NodeGroup
 	}
 	scaleDownUnneededDuration := defaults.ScaleDownUnneededTime
 	if _, ok := mcdAnnotations[ScaleDownUnneededTimeAnnotation]; ok {
-		if timeValue, err := time.ParseDuration(mcdAnnotations[ScaleDownUnneededTimeAnnotation]); err == nil {
-			scaleDownUnneededDuration = timeValue
+		if durationVal, err := time.ParseDuration(mcdAnnotations[ScaleDownUnneededTimeAnnotation]); err == nil {
+			scaleDownUnneededDuration = durationVal
 		}
 	}
 	scaleDownUnreadyDuration := defaults.ScaleDownUnreadyTime
 	if _, ok := mcdAnnotations[ScaleDownUnreadyTimeAnnotation]; ok {
-		if timeValue, err := time.ParseDuration(mcdAnnotations[ScaleDownUnreadyTimeAnnotation]); err == nil {
-			scaleDownUnreadyDuration = timeValue
+		if durationVal, err := time.ParseDuration(mcdAnnotations[ScaleDownUnreadyTimeAnnotation]); err == nil {
+			scaleDownUnreadyDuration = durationVal
 		}
 	}
 	maxNodeProvisionDuration := defaults.MaxNodeProvisionTime
 	if _, ok := mcdAnnotations[MaxNodeProvisionTimeAnnotation]; ok {
-		if timeValue, err := time.ParseDuration(mcdAnnotations[MaxNodeProvisionTimeAnnotation]); err == nil {
-			maxNodeProvisionDuration = timeValue
+		if durationVal, err := time.ParseDuration(mcdAnnotations[MaxNodeProvisionTimeAnnotation]); err == nil {
+			maxNodeProvisionDuration = durationVal
 		}
 	}
 	return &config.NodeGroupAutoscalingOptions{

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	v1 "k8s.io/api/apps/v1"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	v1 "k8s.io/api/apps/v1"
 
 	machinecodes "github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
@@ -685,8 +686,8 @@ func TestGetOptions(t *testing.T) {
 			g := NewWithT(t)
 			stop := make(chan struct{})
 			defer close(stop)
-			controlMachineObjects, targetCoreObjects := setupEnv(&entry.setup)
-			m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, nil, controlMachineObjects, targetCoreObjects)
+			controlMachineObjects, targetCoreObjects, _ := setupEnv(&entry.setup)
+			m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, nil, controlMachineObjects, targetCoreObjects, nil)
 			defer trackers.Stop()
 			waitForCacheSync(t, stop, hasSyncedCacheFns)
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -24,10 +24,12 @@ import (
 	"math"
 	"strings"
 	"testing"
+	"time"
 
 	machinecodes "github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes"
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	customfake "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mcm/fakeclient"
+	"k8s.io/autoscaler/cluster-autoscaler/config"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	. "github.com/onsi/gomega"
@@ -576,6 +578,141 @@ func TestNodes(t *testing.T) {
 					}
 				}
 				g.Expect(found).To(BeTrue())
+			}
+		})
+	}
+}
+
+func TestGetOptions(t *testing.T) {
+	type expect struct {
+		ngOptions *config.NodeGroupAutoscalingOptions
+		err       error
+	}
+	type data struct {
+		name   string
+		setup  setup
+		expect expect
+	}
+	table := []data{
+		{
+			"should throw error if machinedeployment cannot be found",
+			setup{
+				nodeGroups: []string{nodeGroup1},
+			},
+			expect{
+				err: fmt.Errorf("unable to fetch MachineDeployment object machinedeployment-1, Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
+			},
+		},
+		{
+			"should return default nodegroupautoscalingoptions if none are provided",
+			setup{
+				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
+				nodeGroups:         []string{nodeGroup1},
+			},
+			expect{
+				ngOptions: &config.NodeGroupAutoscalingOptions{
+					ScaleDownUtilizationThreshold:    0.5,
+					ScaleDownGpuUtilizationThreshold: 0.5,
+					ScaleDownUnneededTime:            1 * time.Minute,
+					ScaleDownUnreadyTime:             1 * time.Minute,
+					MaxNodeProvisionTime:             1 * time.Minute,
+				},
+				err: nil,
+			},
+		},
+		{
+			"should return nodegroupautoscalingoptions with values from mcd if all annotations are present",
+			setup{
+				machineDeployments: newMachineDeployments(
+					1,
+					2,
+					nil,
+					map[string]string{
+						ScaleDownUtilizationThresholdAnnotation:    "0.7",
+						ScaleDownGpuUtilizationThresholdAnnotation: "0.7",
+						ScaleDownUnneededTimeAnnotation:            "5m",
+						ScaleDownUnreadyTimeAnnotation:             "5m",
+						MaxNodeProvisionTimeAnnotation:             "5m",
+					},
+					nil,
+				),
+				nodeGroups: []string{nodeGroup1},
+			},
+			expect{
+				ngOptions: &config.NodeGroupAutoscalingOptions{
+					ScaleDownUtilizationThreshold:    0.7,
+					ScaleDownGpuUtilizationThreshold: 0.7,
+					ScaleDownUnneededTime:            5 * time.Minute,
+					ScaleDownUnreadyTime:             5 * time.Minute,
+					MaxNodeProvisionTime:             5 * time.Minute,
+				},
+				err: nil,
+			},
+		},
+		{
+			"should return nodegroupautoscalingoptions with annotations values from mcd and remaining defaults",
+			setup{
+				machineDeployments: newMachineDeployments(
+					1,
+					2,
+					nil,
+					map[string]string{
+						ScaleDownUtilizationThresholdAnnotation: "0.7",
+						ScaleDownUnneededTimeAnnotation:         "5m",
+						MaxNodeProvisionTimeAnnotation:          "2m",
+					},
+					nil,
+				),
+				nodeGroups: []string{nodeGroup1},
+			},
+			expect{
+				ngOptions: &config.NodeGroupAutoscalingOptions{
+					ScaleDownUtilizationThreshold:    0.7,
+					ScaleDownGpuUtilizationThreshold: 0.5,
+					ScaleDownUnneededTime:            5 * time.Minute,
+					ScaleDownUnreadyTime:             1 * time.Minute,
+					MaxNodeProvisionTime:             2 * time.Minute,
+				},
+				err: nil,
+			},
+		},
+	}
+
+	for _, entry := range table {
+		entry := entry // have a shallow copy of the entry for parallelization of tests
+		t.Run(entry.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			stop := make(chan struct{})
+			defer close(stop)
+			controlMachineObjects, targetCoreObjects := setupEnv(&entry.setup)
+			m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, nil, controlMachineObjects, targetCoreObjects)
+			defer trackers.Stop()
+			waitForCacheSync(t, stop, hasSyncedCacheFns)
+
+			md, err := buildMachineDeploymentFromSpec(entry.setup.nodeGroups[0], m)
+			g.Expect(err).To(BeNil())
+
+			ngAutoScalingOpDefaults := config.NodeGroupAutoscalingOptions{
+				ScaleDownUtilizationThreshold:    0.5,
+				ScaleDownGpuUtilizationThreshold: 0.5,
+				ScaleDownUnneededTime:            1 * time.Minute,
+				ScaleDownUnreadyTime:             1 * time.Minute,
+				MaxNodeProvisionTime:             1 * time.Minute,
+			}
+
+			options, err := md.GetOptions(ngAutoScalingOpDefaults)
+
+			if entry.expect.err != nil {
+				g.Expect(err).To(Equal(entry.expect.err))
+				g.Expect(options).To(BeNil())
+			} else {
+				g.Expect(err).To(BeNil())
+				g.Expect(*options).To(HaveField("ScaleDownUtilizationThreshold", entry.expect.ngOptions.ScaleDownUtilizationThreshold))
+				g.Expect(*options).To(HaveField("ScaleDownGpuUtilizationThreshold", entry.expect.ngOptions.ScaleDownGpuUtilizationThreshold))
+				g.Expect(*options).To(HaveField("ScaleDownUnneededTime", entry.expect.ngOptions.ScaleDownUnneededTime))
+				g.Expect(*options).To(HaveField("ScaleDownUnreadyTime", entry.expect.ngOptions.ScaleDownUnreadyTime))
+				g.Expect(*options).To(HaveField("MaxNodeProvisionTime", entry.expect.ngOptions.MaxNodeProvisionTime))
 			}
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -707,6 +707,16 @@ func validateNodeTemplate(nodeTemplateAttributes *v1alpha1.NodeTemplate) error {
 	return nil
 }
 
+// GetMachineDeploymentSpec returns the machine deployment spec of the provided machine deployment name
+func (m *McmManager) GetMachineDeploymentSpec(machineDeploymentName string) (*v1alpha1.MachineDeployment, error) {
+	md, err := m.machineDeploymentLister.MachineDeployments(m.namespace).Get(machineDeploymentName)
+	if err != nil {
+		return nil, fmt.Errorf("unable to fetch MachineDeployment object %s, Error: %v", machineDeploymentName, err)
+	}
+
+	return md, nil
+}
+
 // GetMachineDeploymentNodeTemplate returns the NodeTemplate of a node belonging to the same worker pool as the machinedeployment
 // If no node present then it forms the nodeTemplate using the one present in machineClass
 func (m *McmManager) GetMachineDeploymentNodeTemplate(machinedeployment *MachineDeployment) (*nodeTemplate, error) {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -707,14 +707,14 @@ func validateNodeTemplate(nodeTemplateAttributes *v1alpha1.NodeTemplate) error {
 	return nil
 }
 
-// GetMachineDeploymentSpec returns the machine deployment spec of the provided machine deployment name
-func (m *McmManager) GetMachineDeploymentSpec(machineDeploymentName string) (*v1alpha1.MachineDeployment, error) {
+// GetMachineDeploymentAnnotations returns the annotations present on the machine deployment for the provided machine deployment name
+func (m *McmManager) GetMachineDeploymentAnnotations(machineDeploymentName string) (map[string]string, error) {
 	md, err := m.machineDeploymentLister.MachineDeployments(m.namespace).Get(machineDeploymentName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch MachineDeployment object %s, Error: %v", machineDeploymentName, err)
 	}
 
-	return md, nil
+	return md.Annotations, nil
 }
 
 // GetMachineDeploymentNodeTemplate returns the NodeTemplate of a node belonging to the same worker pool as the machinedeployment


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updated the [`machineDeployment.GetOptions()`](https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go#L425-L427) method to read annotations form `machineDeployment`s and populate node group values in its [`NodeGroupAutoscalingOptions`](https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/config/autoscaling_options.go#L35-L49) struct

**Which issue(s) this PR fixes**:
Fixes partially #240 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Autoscaler will now add NodeGroupAutoscalingOptions to node groups from annotations present in its corresponding machineDeployments
```
