### PR TITLE
Add vpa release pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -63,3 +63,86 @@ autoscaler:
               slack_cfg_name: 'scp_workspace'
         component_descriptor:
           snapshot_ctx_repository: gardener-public
+vertical-pod-autoscaler:
+  template: 'default'
+  base_definition:
+    repo:
+      source_labels:
+      - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
+        value:
+          policy: 'scan'
+          path_config:
+            exclude_paths:
+              - '^vendor/.*'
+              - '.*/vendor/.*'
+              - '^addon-resizer/.*'
+              - '^balancer/.*'
+              - '^cluster-autoscaler/.*'
+    traits:
+      version:
+        preprocess:
+          'inject-commit-hash'
+        inject_effective_version: true
+        versionfile: 'vertical-pod-autoscaler/common/VERSION'
+      publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
+        dockerimages:
+          vpa-recommender:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            registry: 'gcr-readwrite'
+            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender'
+            dockerfile: './vertical-pod-autoscaler/pkg/recommender/Dockerfile'
+          vpa-updater:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            registry: 'gcr-readwrite'
+            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater'
+            dockerfile: './vertical-pod-autoscaler/pkg/updater/Dockerfile'
+           vpa-admission-controller:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            registry: 'gcr-readwrite'
+            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller'
+            dockerfile: './vertical-pod-autoscaler/pkg/admission-controller/Dockerfile'
+    steps:
+      test:
+        image: 'golang:1.20.5'
+      build:
+        image: 'golang:1.20.5'
+        output_dir: 'binary'
+  jobs:
+    head-update:
+      traits:
+        component_descriptor:
+          snapshot_ctx_repository: gardener-public
+        draft_release: ~
+    pull-request:
+      traits:
+        pull-request: ~
+    release:
+      traits:
+        version:
+          preprocess: 'finalize'
+        release:
+          nextversion: 'bump_minor'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'C017KSLTF4H' # gardener-autoscaling
+              slack_cfg_name: 'scp_workspace'
+        component_descriptor:
+          snapshot_ctx_repository: gardener-public

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -80,10 +80,9 @@ vertical-pod-autoscaler:
               - '^cluster-autoscaler/.*'
     traits:
       version:
-        preprocess:
-          'inject-commit-hash'
         inject_effective_version: true
-        versionfile: 'vertical-pod-autoscaler/common/VERSION'
+        read_callback: .ci/read-vpa-version.sh
+        write_callback: .ci/write-vpa-version.sh
       publish:
         oci-builder: docker-buildx
         platforms:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -137,6 +137,9 @@ vertical-pod-autoscaler:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+          git_tags:
+            - ref_template: refs/tags/vpa-{VERSION}
+          on_tag_conflict: 'fail'
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -107,7 +107,7 @@ vertical-pod-autoscaler:
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater'
             dockerfile: './vertical-pod-autoscaler/pkg/updater/Dockerfile'
-           vpa-admission-controller:
+          vpa-admission-controller:
             inputs:
               repos:
                 source: ~ # default

--- a/.ci/read-vpa-version.sh
+++ b/.ci/read-vpa-version.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env sh
 
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 cat ../vertical-pod-autoscaler/common/version.go | grep 'const VerticalPodAutoscalerVersion' | cut -d " " -f 4 | tr -d '"'

--- a/.ci/read-vpa-version.sh
+++ b/.ci/read-vpa-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+cat ../vertical-pod-autoscaler/common/version.go | grep 'const VerticalPodAutoscalerVersion' | cut -d " " -f 4 | tr -d '"'

--- a/.ci/write-vpa-version.sh
+++ b/.ci/write-vpa-version.sh
@@ -1,3 +1,17 @@
 #!/usr/bin/env sh
 
+# Copyright (c) 2023 SAP SE or an SAP affiliate company. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 sed -i s/'^\(const VerticalPodAutoscalerVersion = "\).*"'/\\1$1'"'/ vertical-pod-autoscaler/common/version.go

--- a/.ci/write-vpa-version.sh
+++ b/.ci/write-vpa-version.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+sed -i s/'^\(const VerticalPodAutoscalerVersion = "\).*"'/\\1$1'"'/ vertical-pod-autoscaler/common/version.go

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -163,7 +163,9 @@ skipped_dirs = ['Godeps', 'third_party', '_gopath', '_output', '.git', 'cluster/
                 "cluster-autoscaler/cloudprovider/mcm",
                 "cluster-autoscaler/integration",
                 "cluster-autoscaler/hack",
-                "cluster-autoscaler/cloudprovider/builder/builder_all.go"
+                "cluster-autoscaler/cloudprovider/builder/builder_all.go",
+                ".ci/read-vpa-version.sh",
+                ".ci/write-vpa-version.sh"
                 ]
 
 # list all the files contain 'DO NOT EDIT', but are not generated


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a pipeline to release VPA from our fork. We're currently looking into releasing a forked VPA in the context of a complex bug where we need more debug output in the logs in case the bug occurs. This won't be a change that will be merged upstream and will only be of temporary nature.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
