### PR TITLE
Add multistage Dockerfiles for VPA components

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -97,7 +97,7 @@ vertical-pod-autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender'
-            dockerfile: './vertical-pod-autoscaler/pkg/recommender/Dockerfile'
+            dockerfile: './vertical-pod-autoscaler/Dockerfile.recommender'
           vpa-updater:
             inputs:
               repos:
@@ -106,7 +106,7 @@ vertical-pod-autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater'
-            dockerfile: './vertical-pod-autoscaler/pkg/updater/Dockerfile'
+            dockerfile: './vertical-pod-autoscaler/Dockerfile.updater'
           vpa-admission-controller:
             inputs:
               repos:
@@ -115,7 +115,7 @@ vertical-pod-autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller'
-            dockerfile: './vertical-pod-autoscaler/pkg/admission-controller/Dockerfile'
+            dockerfile: './vertical-pod-autoscaler/Dockerfile.admissioncontroller'
     steps:
       test:
         image: 'golang:1.20.5'

--- a/vertical-pod-autoscaler/Dockerfile.admissioncontroller
+++ b/vertical-pod-autoscaler/Dockerfile.admissioncontroller
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM --platform=$BUILDPLATFORM golang:1.20.5 as builder
+
+ENV GOPATH /gopath/
+ENV PATH $GOPATH/bin:$PATH
+
+COPY . /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
+WORKDIR /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
+
+ARG TARGETOS TARGETARCH
+
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/admission-controller -mod vendor -o admission-controller-$TARGETARCH
+
+FROM gcr.io/distroless/static:latest
+MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
+
+ARG TARGETARCH
+
+COPY --from=builder /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/admission-controller/admission-controller-$TARGETARCH /admission-controller
+
+ENTRYPOINT ["/admission-controller"]
+CMD ["--v=4", "--stderrthreshold=info"]

--- a/vertical-pod-autoscaler/Dockerfile.recommender
+++ b/vertical-pod-autoscaler/Dockerfile.recommender
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM --platform=$BUILDPLATFORM golang:1.20.5 as builder
+
+ENV GOPATH /gopath/
+ENV PATH $GOPATH/bin:$PATH
+
+COPY . /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
+WORKDIR /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
+
+ARG TARGETOS TARGETARCH
+
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/recommender -mod vendor -o recommender-$TARGETARCH
+
+FROM gcr.io/distroless/static:latest
+MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
+
+ARG TARGETARCH
+
+COPY --from=builder /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/recommender-$TARGETARCH /recommender
+
+ENTRYPOINT ["/recommender"]
+CMD ["--v=4", "--stderrthreshold=info", "--prometheus-address=http://prometheus.monitoring.svc"]

--- a/vertical-pod-autoscaler/Dockerfile.updater
+++ b/vertical-pod-autoscaler/Dockerfile.updater
@@ -1,0 +1,34 @@
+# Copyright 2017 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM --platform=$BUILDPLATFORM golang:1.20.5 as builder
+
+ENV GOPATH /gopath/
+ENV PATH $GOPATH/bin:$PATH
+
+COPY . /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
+WORKDIR /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler
+
+ARG TARGETOS TARGETARCH
+
+RUN CGO_ENABLED=0 GOARCH=$TARGETARCH GOOS=$TARGETOS go build -C pkg/updater -mod vendor -o updater-$TARGETARCH
+
+FROM gcr.io/distroless/static:latest
+MAINTAINER Krzysztof Grygiel "kgrygiel@google.com"
+
+ARG TARGETARCH
+
+COPY --from=builder /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/updater/updater-$TARGETARCH /updater
+
+ENTRYPOINT ["/updater"]
+CMD ["--v=4", "--stderrthreshold=info"]


### PR DESCRIPTION
**What this PR does / why we need it**:
Switch from complicated Makefile to multistage Dockerfiles for building VPA components

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
