### PR TITLE
Fix VPA pipelines

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -67,6 +67,9 @@ vertical-pod-autoscaler:
   template: 'default'
   base_definition:
     repo:
+      trigger_paths:
+        include:
+          - 'vertical-pod-autoscaler'
       source_labels:
       - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
         value:
@@ -97,7 +100,8 @@ vertical-pod-autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender'
-            dockerfile: './vertical-pod-autoscaler/Dockerfile.recommender'
+            dockerfile: 'Dockerfile.recommender'
+            dir: 'vertical-pod-autoscaler'
           vpa-updater:
             inputs:
               repos:
@@ -106,7 +110,8 @@ vertical-pod-autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater'
-            dockerfile: './vertical-pod-autoscaler/Dockerfile.updater'
+            dockerfile: 'Dockerfile.updater'
+            dir: 'vertical-pod-autoscaler'
           vpa-admission-controller:
             inputs:
               repos:
@@ -115,7 +120,8 @@ vertical-pod-autoscaler:
                 build: ~
             registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller'
-            dockerfile: './vertical-pod-autoscaler/Dockerfile.admissioncontroller'
+            dockerfile: 'Dockerfile.admissioncontroller'
+            dir: 'vertical-pod-autoscaler'
     steps:
       test:
         image: 'golang:1.20.5'


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fix docker context for VPA image builds
* Trigger VPA jobs only on changes in the `vertical-pod-autoscaler` directory

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
