### PR TITLE
Ensure VPA pipelines use scripts for determining versions

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -83,6 +83,7 @@ vertical-pod-autoscaler:
               - '^cluster-autoscaler/.*'
     traits:
       version:
+        version_interface: 'callback'
         inject_effective_version: true
         read_callback: .ci/read-vpa-version.sh
         write_callback: .ci/write-vpa-version.sh


### PR DESCRIPTION
**What this PR does / why we need it**:
Although we've set scripts for reading and writing the VPA version, the pipeline still uses the VERSION file for determining the VPA version. That's not what we want, this file is only used for the CA.

Therefore, set the `version_interface` explicitly to use the defined callbacks.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
