### PR TITLE
Fix how write-vpa-version reads from stdin

### DIFF
--- a/.ci/write-vpa-version.sh
+++ b/.ci/write-vpa-version.sh
@@ -14,4 +14,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-sed -i s/'^\(const VerticalPodAutoscalerVersion = "\).*"'/\\1$1'"'/ vertical-pod-autoscaler/common/version.go
+new_version=$(cat -)
+sed -i s/'^\(const VerticalPodAutoscalerVersion = "\).*"'/\\1${new_version}'"'/ vertical-pod-autoscaler/common/version.go


### PR DESCRIPTION
**What this PR does / why we need it**:
The version is passed to the script via `stdin` without a `newline` at the end. Therefore, we need to use something like `cat -` to get the data.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
