### PR TITLE
switch GCR -> Artifact-Registry

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -18,6 +18,8 @@ autoscaler:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -30,7 +32,7 @@ autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/cluster-autoscaler
             dockerfile: './cluster-autoscaler/Dockerfile'
     steps:
       test:
@@ -42,7 +44,8 @@ autoscaler:
     head-update:
       traits:
         component_descriptor:
-          snapshot_ctx_repository: gardener-public
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -51,6 +54,12 @@ autoscaler:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            cluster-autoscaler:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
         release:
           nextversion: 'bump_minor'
         slack:
@@ -59,8 +68,7 @@ autoscaler:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          snapshot_ctx_repository: gardener-public
+
 vertical-pod-autoscaler:
   base_definition:
     repo:
@@ -84,6 +92,8 @@ vertical-pod-autoscaler:
         inject_effective_version: true
         read_callback: .ci/read-vpa-version.sh
         write_callback: .ci/write-vpa-version.sh
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -96,7 +106,7 @@ vertical-pod-autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
             dockerfile: 'Dockerfile.recommender'
             dir: 'vertical-pod-autoscaler'
           vpa-updater:
@@ -105,7 +115,7 @@ vertical-pod-autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater
             dockerfile: 'Dockerfile.updater'
             dir: 'vertical-pod-autoscaler'
           vpa-admission-controller:
@@ -114,7 +124,7 @@ vertical-pod-autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller
             dockerfile: 'Dockerfile.admissioncontroller'
             dir: 'vertical-pod-autoscaler'
     steps:
@@ -127,7 +137,8 @@ vertical-pod-autoscaler:
     head-update:
       traits:
         component_descriptor:
-          snapshot_ctx_repository: gardener-public
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -136,6 +147,16 @@ vertical-pod-autoscaler:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            vpa-recommender:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
+            vpa-updater:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater
+            vpa-admission-controller:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller
         release:
           nextversion: 'bump_minor'
           git_tags:
@@ -147,5 +168,3 @@ vertical-pod-autoscaler:
             internal_scp_workspace:
               channel_name: 'C017KSLTF4H' # gardener-autoscaling
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          snapshot_ctx_repository: gardener-public

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,5 +1,4 @@
 autoscaler:
-  template: 'default'
   base_definition:
     repo:
       source_labels:
@@ -31,7 +30,6 @@ autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler'
             dockerfile: './cluster-autoscaler/Dockerfile'
     steps:
@@ -64,7 +62,6 @@ autoscaler:
         component_descriptor:
           snapshot_ctx_repository: gardener-public
 vertical-pod-autoscaler:
-  template: 'default'
   base_definition:
     repo:
       trigger_paths:
@@ -99,7 +96,6 @@ vertical-pod-autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender'
             dockerfile: 'Dockerfile.recommender'
             dir: 'vertical-pod-autoscaler'
@@ -109,7 +105,6 @@ vertical-pod-autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater'
             dockerfile: 'Dockerfile.updater'
             dir: 'vertical-pod-autoscaler'
@@ -119,7 +114,6 @@ vertical-pod-autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller'
             dockerfile: 'Dockerfile.admissioncontroller'
             dir: 'vertical-pod-autoscaler'


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
