### PR TITLE
Switch VPA pipeline to vpa specific branch

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -72,6 +72,7 @@ autoscaler:
 vertical-pod-autoscaler:
   base_definition:
     repo:
+      branch: rel-vertical-pod-autoscaler
       trigger_paths:
         include:
           - 'vertical-pod-autoscaler'


### PR DESCRIPTION
**What this PR does / why we need it**:
We have created a branch specific for VPA updates, therefore the VPA pipeline should only work with that branch

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
