### PR TITLE
Remove `snapshot_ctx_repository` attr from pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -44,7 +44,7 @@ autoscaler:
     head-update:
       traits:
         component_descriptor:
-          snapshot_ctx_repository: gardener-public
+          ocm_repository: gardener-public
         draft_release: ~
     pull-request:
       traits:
@@ -61,5 +61,4 @@ autoscaler:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          snapshot_ctx_repository: gardener-public
+        component_descriptor: ~


### PR DESCRIPTION
This attribute will be removed with a future release of cc-utils. Hence, it must be removed from the pipeline definition as well. However, this will have no impact on the current functionality as the `ocm_repository` will be used as default for both "snapshot" and "non-snapshot" component descriptors.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
The second occurrence of `snapshot_ctx_repository` is just removed and not replaced in this case, because the respective job has a release trait and thus the `snapshot_ctx_repository` was never used anyway.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
