### PR TITLE
Remove `snapshot_ctx_repository` attr from pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -32,7 +32,7 @@ autoscaler:
     head-update:
       traits:
         component_descriptor:
-          snapshot_ctx_repository: gardener-public
+          ocm_repository: gardener-public
         draft_release: ~
     pull-request:
       traits:
@@ -49,5 +49,4 @@ autoscaler:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor:
-          snapshot_ctx_repository: gardener-public
+        component_descriptor: ~


### PR DESCRIPTION
The pipeline seems to not be used anymore. Thus and because it contains legacy attributes (`snapshot_ctx_repository`) which are going to be not supported anymore, the pipeline should be disabled.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
