### PR TITLE
Disable rendering of pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,4 +1,5 @@
 autoscaler:
+  render_pipeline: False
   template: 'default'
   base_definition:
     repo: ~


### PR DESCRIPTION
The pipeline seems to not be used anymore. Thus and because it contains legacy attributes (`snapshot_ctx_repository`) which are going to be not supported anymore, the pipeline should be disabled.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
