### PR TITLE
Fix: trigger VPA pipeline on changes in .ci folder

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -76,6 +76,7 @@ vertical-pod-autoscaler:
       trigger_paths:
         include:
           - 'vertical-pod-autoscaler'
+          - '.ci'
       source_labels:
       - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
         value:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add the `.ci` folder to the list of triggers for the VPA pipeline. My original intention with leaving this directory out was to avoid automatic pipeline runs when only the `.ci` folder changed, as this would still use the old pipeline definitions and be therefore not really useful. However, it turns out that the concourse git resource filters out commits that don't match the `path` property entirely, such that even manual pipeline runs never see this commit.

This is not what we want, therefore let's accept the inconvenience of unnecessary pipeline runs.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
