### PR TITLE
Remove unnecessary things from VPA pipeline

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -65,15 +65,6 @@ vertical-pod-autoscaler:
         image: 'golang:1.20.5'
         output_dir: 'binary'
   jobs:
-    head-update:
-      traits:
-        component_descriptor:
-          ocm_repository_mappings:
-            - repository: europe-docker.pkg.dev/gardener-project/releases
-        draft_release: ~
-    pull-request:
-      traits:
-        pull-request: ~
     release:
       traits:
         version:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -84,6 +84,7 @@ vertical-pod-autoscaler:
           git_tags:
             - ref_template: refs/tags/vpa-{VERSION}
           on_tag_conflict: 'fail'
+          release_notes_policy: 'disabled'
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:


### PR DESCRIPTION
**What this PR does / why we need it**:
* make sure that we don't get CA release notes when doing a VPA release
* remove unnecessary jobs `head-update` and `pull-request`, as tests are via github actions

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
