### PR TITLE
Bring back VPA pipeline, but with render_pipeline: false

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -68,3 +68,97 @@ autoscaler:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
+vertical-pod-autoscaler:
+  render_pipeline: false
+  base_definition:
+    repo:
+      branch: rel-vertical-pod-autoscaler
+      trigger_paths:
+        include:
+          - 'vertical-pod-autoscaler'
+          - '.ci'
+      source_labels:
+      - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
+        value:
+          policy: 'scan'
+          path_config:
+            exclude_paths:
+              - '^vendor/.*'
+              - '.*/vendor/.*'
+              - '^addon-resizer/.*'
+              - '^balancer/.*'
+              - '^cluster-autoscaler/.*'
+    traits:
+      version:
+        version_interface: 'callback'
+        inject_effective_version: true
+        read_callback: .ci/read-vpa-version.sh
+        write_callback: .ci/write-vpa-version.sh
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+      publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
+        dockerimages:
+          vpa-recommender:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
+            dockerfile: 'Dockerfile.recommender'
+            dir: 'vertical-pod-autoscaler'
+          vpa-updater:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater
+            dockerfile: 'Dockerfile.updater'
+            dir: 'vertical-pod-autoscaler'
+          vpa-admission-controller:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller
+            dockerfile: 'Dockerfile.admissioncontroller'
+            dir: 'vertical-pod-autoscaler'
+    steps:
+      test:
+        image: 'golang:1.20.5'
+      build:
+        image: 'golang:1.20.5'
+        output_dir: 'binary'
+  jobs:
+    release:
+      traits:
+        version:
+          preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            vpa-recommender:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
+            vpa-updater:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater
+            vpa-admission-controller:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller
+        release:
+          nextversion: 'bump_minor'
+          git_tags:
+            - ref_template: refs/tags/vpa-{VERSION}
+          on_tag_conflict: 'fail'
+          release_notes_policy: 'disabled'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'C017KSLTF4H' # gardener-autoscaling
+              slack_cfg_name: 'scp_workspace'


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to get rid of the pipeline in our CI, we need to bring back the definition, but introduce the property `render_pipeline: false`. Otherwise the rendering job will fail and the removed pipeline will never be cleaned up.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
