### PR TITLE
Bring back CA pipeline, but with render_pipeline: false

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,3 +1,74 @@
+autoscaler:
+  render_pipeline: false
+  base_definition:
+    repo:
+      source_labels:
+      - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
+        value:
+          policy: 'scan'
+          path_config:
+            exclude_paths:
+              - '.*/aws-sdk-go/.*'
+              - '^vendor/.*'
+              - '.*/vendor/.*'
+              - '.*/cloudprovider/((?!mcm/).)*/.*'
+              - '^addon-resizer/.*'
+              - '^vertical-pod-autoscaler/.*'
+    traits:
+      version:
+        preprocess:
+          'inject-commit-hash'
+        inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
+      publish:
+        oci-builder: docker-buildx
+        platforms:
+        - linux/amd64
+        - linux/arm64
+        dockerimages:
+          cluster-autoscaler:
+            inputs:
+              repos:
+                source: ~ # default
+              steps:
+                build: ~
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/cluster-autoscaler
+            dockerfile: './cluster-autoscaler/Dockerfile'
+    steps:
+      test:
+        image: 'golang:1.20.5'
+      build:
+        image: 'golang:1.20.5'
+        output_dir: 'binary'
+  jobs:
+    head-update:
+      traits:
+        component_descriptor:
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
+        draft_release: ~
+    pull-request:
+      traits:
+        pull-request: ~
+    release:
+      traits:
+        version:
+          preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            cluster-autoscaler:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
+        release:
+          nextversion: 'bump_minor'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'C0170QTBJUW' # gardener-mcm
+              slack_cfg_name: 'scp_workspace'
 vertical-pod-autoscaler:
   base_definition:
     repo:


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to get rid of the pipeline in our CI, we need to bring back the definition, but introduce the property `render_pipeline: false`. Otherwise the rendering job will fail and the removed pipeline will never be cleaned up.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
