### PR TITLE
Added failed machine to prevent scaledown

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -226,6 +226,23 @@ func TestDeleteNodes(t *testing.T) {
 			},
 		},
 		{
+			"should not scale down a machine deployment when the corresponding machine is already in failed state",
+			setup{
+				nodes:              newNodes(2, "fakeID", []bool{false, false}),
+				machines:           newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				machineSets:        newMachineSets(1, "machinedeployment-1"),
+				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
+				nodeGroups:         []string{nodeGroup1},
+			},
+			action{node: newNodes(1, "fakeID", []bool{false})[0]},
+			expect{
+				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{true}),
+				mdName:     "machinedeployment-1",
+				mdReplicas: 2,
+				err:        nil,
+			},
+		},
+		{
 			"should not scale down a machine deployment below the minimum",
 			setup{
 				nodes:              newNodes(1, "fakeID", []bool{true}),

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -228,7 +228,7 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should not scale down a machine deployment when the corresponding machine is already in failed state",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{false, false}),
+				nodes:              newNodes(2, "fakeID", []bool{true, false}),
 				machines:           newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
@@ -236,7 +236,7 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID", []bool{false})[0]},
 			expect{
-				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{true}),
+				machines:   newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
 				err:        nil,

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -990,8 +990,8 @@ func buildGenericLabels(template *nodeTemplate, nodeName string) map[string]stri
 
 // isMachineFailedOrTerminating returns true if machine is already being terminated or considered for termination by autoscaler.
 func isMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
-	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.LastOperation.State == v1alpha1.MachineStateFailed {
-		klog.Infof("Machine %q is already being failed or terminated, and hence skipping the deletion", machine.Name)
+	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
+		klog.Infof("Machine %q is already being terminated or in a failed phase, and hence skipping the deletion", machine.Name)
 		return true
 	}
 	return false

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -525,11 +525,7 @@ func (m *McmManager) prioritizeMachinesForDeletion(targetMachineRefs []*Ref, mdN
 				return false, nil
 			}
 			expectedToTerminateMachineNodePairs[mc.Name] = mc.Labels["node"]
-			retry, err := m.updateAnnotationOnMachine(ctx, mc.Name, machinePriorityAnnotation, "1")
-			if err == nil {
-				klog.Infof("Machine %s of machineDeployment %s marked with priority 1 successfully", machineRef.Name, mdName)
-			}
-			return retry, err
+			return m.updateAnnotationOnMachine(ctx, mc.Name, machinePriorityAnnotation, "1")
 		}, "Machine", "update", machineRef.Name); err != nil {
 			klog.Errorf("could not prioritize machine %s for deletion, aborting scale in of machine deployment, Error: %v", machineRef.Name, err)
 			return 0, fmt.Errorf("could not prioritize machine %s for deletion, aborting scale in of machine deployment, Error: %v", machineRef.Name, err)
@@ -562,6 +558,9 @@ func (m *McmManager) updateAnnotationOnMachine(ctx context.Context, mcName strin
 		clone.Annotations[key] = val
 	}
 	_, err = m.machineClient.Machines(machine.Namespace).Update(ctx, clone, metav1.UpdateOptions{})
+	if err == nil {
+		klog.Infof("Machine %s marked with priority 1 successfully", mcName)
+	}
 	return true, err
 }
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -525,13 +525,15 @@ func (m *McmManager) prioritizeMachinesForDeletion(targetMachineRefs []*Ref, mdN
 				return false, nil
 			}
 			expectedToTerminateMachineNodePairs[mc.Name] = mc.Labels["node"]
-			return m.updateAnnotationOnMachine(ctx, mc.Name, machinePriorityAnnotation, "1")
+			retry, err := m.updateAnnotationOnMachine(ctx, mc.Name, machinePriorityAnnotation, "1")
+			if err == nil {
+				klog.Infof("Machine %s of machineDeployment %s marked with priority 1 successfully", machineRef.Name, mdName)
+			}
+			return retry, err
 		}, "Machine", "update", machineRef.Name); err != nil {
 			klog.Errorf("could not prioritize machine %s for deletion, aborting scale in of machine deployment, Error: %v", machineRef.Name, err)
 			return 0, fmt.Errorf("could not prioritize machine %s for deletion, aborting scale in of machine deployment, Error: %v", machineRef.Name, err)
 		}
-		// Break out of loop when update succeeds
-		klog.Infof("Machine %s of machineDeployment %s marked with priority 1 successfully", machineRef.Name, mdName)
 	}
 	klog.V(2).Infof("Expected to remove following {machineRef: corresponding node} pairs %s", expectedToTerminateMachineNodePairs)
 	return len(expectedToTerminateMachineNodePairs), nil

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -521,7 +521,7 @@ func (m *McmManager) prioritizeMachinesForDeletion(targetMachineRefs []*Ref, mdN
 				klog.Errorf("Unable to fetch Machine object %s, Error: %v", machineRef.Name, err)
 				return true, err
 			}
-			if isMachineTerminating(mc) {
+			if isMachineFailedOrTerminating(mc) {
 				return false, nil
 			}
 			expectedToTerminateMachineNodePairs[mc.Name] = mc.Labels["node"]
@@ -988,10 +988,10 @@ func buildGenericLabels(template *nodeTemplate, nodeName string) map[string]stri
 	return result
 }
 
-// isMachineTerminating returns true if machine is already being terminated or considered for termination by autoscaler.
-func isMachineTerminating(machine *v1alpha1.Machine) bool {
-	if !machine.GetDeletionTimestamp().IsZero() {
-		klog.Infof("Machine %q is already being terminated, and hence skipping the deletion", machine.Name)
+// isMachineFailedOrTerminating returns true if machine is already being terminated or considered for termination by autoscaler.
+func isMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
+	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.LastOperation.State == v1alpha1.MachineStateFailed {
+		klog.Infof("Machine %q is already being failed or terminated, and hence skipping the deletion", machine.Name)
 		return true
 	}
 	return false


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR now prevents the CA from scaling down a machine deployment due to a machine in failed phase.

**Which issue(s) this PR fixes**:
Fixes #118 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
CA will not scale down machine deployment due to a machine in failed phase, this prevents the race condition which was leading to deletion of a new healthy machine.
```
