### PR TITLE
GCR -> Artifact-Registry 

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,5 +1,4 @@
 autoscaler:
-  template: 'default'
   base_definition:
     repo:
       source_labels:
@@ -31,7 +30,6 @@ autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            registry: 'gcr-readwrite'
             image: 'eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler'
             dockerfile: './cluster-autoscaler/Dockerfile'
     steps:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -18,6 +18,8 @@ autoscaler:
         preprocess:
           'inject-commit-hash'
         inject_effective_version: true
+      component_descriptor:
+        ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots
       publish:
         oci-builder: docker-buildx
         platforms:
@@ -30,7 +32,7 @@ autoscaler:
                 source: ~ # default
               steps:
                 build: ~
-            image: 'eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler'
+            image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/cluster-autoscaler
             dockerfile: './cluster-autoscaler/Dockerfile'
     steps:
       test:
@@ -42,7 +44,8 @@ autoscaler:
     head-update:
       traits:
         component_descriptor:
-          ocm_repository: gardener-public
+          ocm_repository_mappings:
+            - repository: europe-docker.pkg.dev/gardener-project/releases
         draft_release: ~
     pull-request:
       traits:
@@ -51,6 +54,12 @@ autoscaler:
       traits:
         version:
           preprocess: 'finalize'
+        component_descriptor:
+          ocm_repository: europe-docker.pkg.dev/gardener-project/releases
+        publish:
+          dockerimages:
+            cluster-autoscaler:
+              image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
         release:
           nextversion: 'bump_minor'
         slack:
@@ -59,4 +68,3 @@ autoscaler:
             internal_scp_workspace:
               channel_name: 'C0170QTBJUW' # gardener-mcm
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~


### PR DESCRIPTION
GCR has been deprecated [0] in favour of Artifact-Registry.

Thus, change push-targets for OCI-Images:

- europe-docker.pkg.dev/gardener-project/snapshots for snapshots
- europe-docker.pkg.dev/gardener-project/releases for releases
- europe-docker.pkg.dev/gardener-project/public for combined view of snapshots + releases

[0]
https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr


**Release note**:

```breaking operator
Change OCI Image Registry from GCR (`eu.gcr.io/gardener-project`) to Artifact-Registry (`europe-docker.pkg.dev/gardener-project/releases`). Users should update their references.

```
