### PR TITLE
[cherry-pick 1.27] populate instance status state when machine lastOperation is Create

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -646,7 +646,7 @@ func findMatchingInstance(nodes []*v1.Node, machine *v1alpha1.Machine) cloudprov
 	// Report InstanceStatus only for `ResourceExhausted` errors
 	return cloudprovider.Instance{
 		Id:     placeholderInstanceIDForMachineObj(machine.Name),
-		Status: checkAndGetResourceExhaustedInstanceStatus(machine),
+		Status: generateInstanceStatus(machine),
 	}
 }
 
@@ -654,17 +654,20 @@ func placeholderInstanceIDForMachineObj(name string) string {
 	return fmt.Sprintf("requested://%s", name)
 }
 
-// checkAndGetResourceExhaustedInstanceStatus returns cloudprovider.InstanceStatus for the machine obj
-func checkAndGetResourceExhaustedInstanceStatus(machine *v1alpha1.Machine) *cloudprovider.InstanceStatus {
-	if machine.Status.LastOperation.Type == v1alpha1.MachineOperationCreate && machine.Status.LastOperation.State == v1alpha1.MachineStateFailed && machine.Status.LastOperation.ErrorCode == machinecodes.ResourceExhausted.String() {
-		return &cloudprovider.InstanceStatus{
-			State: cloudprovider.InstanceCreating,
-			ErrorInfo: &cloudprovider.InstanceErrorInfo{
-				ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
-				ErrorCode:    machinecodes.ResourceExhausted.String(),
-				ErrorMessage: machine.Status.LastOperation.Description,
-			},
+// generateInstanceStatus returns cloudprovider.InstanceStatus for the machine obj
+func generateInstanceStatus(machine *v1alpha1.Machine) *cloudprovider.InstanceStatus {
+	if machine.Status.LastOperation.Type == v1alpha1.MachineOperationCreate {
+		if machine.Status.LastOperation.State == v1alpha1.MachineStateFailed && machine.Status.LastOperation.ErrorCode == machinecodes.ResourceExhausted.String() {
+			return &cloudprovider.InstanceStatus{
+				State: cloudprovider.InstanceCreating,
+				ErrorInfo: &cloudprovider.InstanceErrorInfo{
+					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+					ErrorCode:    machinecodes.ResourceExhausted.String(),
+					ErrorMessage: machine.Status.LastOperation.Description,
+				},
+			}
 		}
+		return &cloudprovider.InstanceStatus{State: cloudprovider.InstanceCreating}
 	}
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks #309 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator github.com/gardener/autoscaler #309 @rishabh-11 
Fixed a bug where the instance status was nil when `machine.Status.LastOperation.Type` = `Create` causing it to not be considered as an unregistered Node and thereby cluster autoscaler never removing it
```
