### PR TITLE
Use `vertical-pod-autoscaler` directory as root for each image build

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -104,16 +104,16 @@ vertical-pod-autoscaler:
         dockerimages:
           vpa-recommender:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-recommender
-            dockerfile: 'Dockerfile'
-            dir: 'vertical-pod-autoscaler/pkg/recommender'
+            dockerfile: 'pkg/recommender/Dockerfile'
+            dir: 'vertical-pod-autoscaler'
           vpa-updater:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-updater
-            dockerfile: 'Dockerfile'
-            dir: 'vertical-pod-autoscaler/pkg/updater'
+            dockerfile: 'pkg/updater/Dockerfile'
+            dir: 'vertical-pod-autoscaler'
           vpa-admission-controller:
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller
-            dockerfile: 'Dockerfile'
-            dir: 'vertical-pod-autoscaler/pkg/admission-controller'
+            dockerfile: 'pkg/admission-controller/Dockerfile'
+            dir: 'vertical-pod-autoscaler'
   jobs:
     release:
       traits:


### PR DESCRIPTION
**What this PR does / why we need it**:
The `Dockerfiles` in the corresponding vpa directories (`recommender`, `updater` and `admission-controller`) are written so that `vertical-pod-autoscaler` has to be used as work directory:
https://github.com/gardener/autoscaler/blob/85cd617e10a2ee4898cb7f7f61747c01f3547d05/vertical-pod-autoscaler/pkg/recommender/Dockerfile#L25
Notice the `go build -C pkg/recommender` part from this line.

This PR tries to adapt the `pipeline_definitions` to that

In the corresponding `Makefile`s the docker command is invoked as follows:
```
docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} -f ./Dockerfile ../../
```

This command is called from e.g. `vertical-pod-autoscaler/pkg/updater`, so notice the `../../` at the end 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
