### PR TITLE
Enhance logging in cases where we have 0 memory recommendations

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -25,7 +25,13 @@ import (
 	"k8s.io/klog/v2"
 
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
-	metrics_quality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
+	metricsquality "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics/quality"
+)
+
+const (
+	targetEstimatorName     = "targetEstimator"
+	lowerBoundEstimatorName = "lowerBoundEstimator"
+	upperBoundEstimatorName = "upperBoundEstimator"
 )
 
 // TODO: Split the estimator to have a separate estimator object for CPU and memory.
@@ -35,12 +41,15 @@ import (
 // containers.
 type ResourceEstimator interface {
 	GetResourceEstimation(s *model.AggregateContainerState) model.Resources
+	SetVpaKeyAndEstimatorName(vpaKey model.VpaID, estimatorName string)
 }
 
 // Implementation of ResourceEstimator that returns constant amount of
 // resources. This can be used as by a fake recommender for test purposes.
 type constEstimator struct {
-	resources model.Resources
+	resources     model.Resources
+	vpaKey        model.VpaID
+	estimatorName string
 }
 
 // Simple implementation of the ResourceEstimator interface. It returns specific
@@ -48,50 +57,57 @@ type constEstimator struct {
 type percentileEstimator struct {
 	cpuPercentile    float64
 	memoryPercentile float64
+	vpaKey           model.VpaID
+	estimatorName    string
 }
 
 type marginEstimator struct {
 	marginFraction float64
 	baseEstimator  ResourceEstimator
+	vpaKey         model.VpaID
+	estimatorName  string
 }
 
 type minResourcesEstimator struct {
 	minResources  model.Resources
 	baseEstimator ResourceEstimator
 	vpaKey        model.VpaID
+	estimatorName string
 }
 
 type confidenceMultiplier struct {
 	multiplier    float64
 	exponent      float64
 	baseEstimator ResourceEstimator
+	vpaKey        model.VpaID
+	estimatorName string
 }
 
 // NewConstEstimator returns a new constEstimator with given resources.
 func NewConstEstimator(resources model.Resources) ResourceEstimator {
-	return &constEstimator{resources}
+	return &constEstimator{resources: resources}
 }
 
 // NewPercentileEstimator returns a new percentileEstimator that uses provided percentiles.
 func NewPercentileEstimator(cpuPercentile float64, memoryPercentile float64) ResourceEstimator {
-	return &percentileEstimator{cpuPercentile, memoryPercentile}
+	return &percentileEstimator{cpuPercentile, memoryPercentile, model.VpaID{}, ""}
 }
 
 // WithMargin returns a given ResourceEstimator with margin applied.
 // The returned resources are equal to the original resources plus (originalResource * marginFraction)
 func WithMargin(marginFraction float64, baseEstimator ResourceEstimator) ResourceEstimator {
-	return &marginEstimator{marginFraction, baseEstimator}
+	return &marginEstimator{marginFraction, baseEstimator, model.VpaID{}, ""}
 }
 
 // WithMinResources returns a given ResourceEstimator with minResources applied.
 // The returned resources are equal to the max(original resources, minResources)
-func WithMinResources(minResources model.Resources, baseEstimator ResourceEstimator, vpaKey model.VpaID) ResourceEstimator {
-	return &minResourcesEstimator{minResources, baseEstimator, vpaKey}
+func WithMinResources(minResources model.Resources, baseEstimator ResourceEstimator) ResourceEstimator {
+	return &minResourcesEstimator{minResources, baseEstimator, model.VpaID{}, ""}
 }
 
 // WithConfidenceMultiplier returns a given ResourceEstimator with confidenceMultiplier applied.
 func WithConfidenceMultiplier(multiplier, exponent float64, baseEstimator ResourceEstimator) ResourceEstimator {
-	return &confidenceMultiplier{multiplier, exponent, baseEstimator}
+	return &confidenceMultiplier{multiplier, exponent, baseEstimator, model.VpaID{}, ""}
 }
 
 // Returns a constant amount of resources.
@@ -99,14 +115,30 @@ func (e *constEstimator) GetResourceEstimation(s *model.AggregateContainerState)
 	return e.resources
 }
 
+func (e *constEstimator) SetVpaKeyAndEstimatorName(vpaKey model.VpaID, estimatorName string) {
+	e.vpaKey = vpaKey
+	e.estimatorName = estimatorName
+}
+
 // Returns specific percentiles of CPU and memory peaks distributions.
 func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerState) model.Resources {
-	return model.Resources{
+	resources := model.Resources{
 		model.ResourceCPU: model.CPUAmountFromCores(
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 	}
+
+	if resources["memory"] == 0 && e.estimatorName == targetEstimatorName {
+		klog.Warningf("Computed %q resources for VPA %q were 0 in percentile estimator of %q!", "memory", klog.KRef(e.vpaKey.Namespace, e.vpaKey.VpaName), e.estimatorName)
+	}
+
+	return resources
+}
+
+func (e *percentileEstimator) SetVpaKeyAndEstimatorName(vpaKey model.VpaID, estimatorName string) {
+	e.vpaKey = vpaKey
+	e.estimatorName = estimatorName
 }
 
 // Returns a non-negative real number that heuristically measures how much
@@ -139,8 +171,17 @@ func (e *confidenceMultiplier) GetResourceEstimation(s *model.AggregateContainer
 	for resource, resourceAmount := range originalResources {
 		scaledResources[resource] = model.ScaleResource(
 			resourceAmount, math.Pow(1.+e.multiplier/confidence, e.exponent))
+		if resource == "memory" && scaledResources[resource] == 0 && e.estimatorName == targetEstimatorName {
+			klog.Warningf("Computed %q resources for VPA %q were 0 after applying confidence: %f in confidence multiplier of %q; they were %v before that!", resource, klog.KRef(e.vpaKey.Namespace, e.vpaKey.VpaName), confidence, e.estimatorName, resourceAmount)
+		}
 	}
 	return scaledResources
+}
+
+func (e *confidenceMultiplier) SetVpaKeyAndEstimatorName(vpaKey model.VpaID, estimatorName string) {
+	e.vpaKey = vpaKey
+	e.estimatorName = estimatorName
+	e.baseEstimator.SetVpaKeyAndEstimatorName(vpaKey, estimatorName)
 }
 
 func (e *marginEstimator) GetResourceEstimation(s *model.AggregateContainerState) model.Resources {
@@ -149,8 +190,17 @@ func (e *marginEstimator) GetResourceEstimation(s *model.AggregateContainerState
 	for resource, resourceAmount := range originalResources {
 		margin := model.ScaleResource(resourceAmount, e.marginFraction)
 		newResources[resource] = originalResources[resource] + margin
+		if resource == "memory" && newResources[resource] == 0 && e.estimatorName == targetEstimatorName {
+			klog.Warningf("Computed %q resources for VPA %q were 0 after applying margin in margin estimator of %q, they were %v before that", resource, klog.KRef(e.vpaKey.Namespace, e.vpaKey.VpaName), e.estimatorName, originalResources[resource])
+		}
 	}
 	return newResources
+}
+
+func (e *marginEstimator) SetVpaKeyAndEstimatorName(vpaKey model.VpaID, estimatorName string) {
+	e.vpaKey = vpaKey
+	e.estimatorName = estimatorName
+	e.baseEstimator.SetVpaKeyAndEstimatorName(vpaKey, estimatorName)
 }
 
 func (e *minResourcesEstimator) GetResourceEstimation(s *model.AggregateContainerState) model.Resources {
@@ -158,10 +208,10 @@ func (e *minResourcesEstimator) GetResourceEstimation(s *model.AggregateContaine
 	newResources := make(model.Resources)
 	for resource, resourceAmount := range originalResources {
 		if resourceAmount < e.minResources[resource] {
-			if resource == "memory" {
-				klog.Warningf("Computed %s resources for VPA %s were below minimum! Computed %v, minimum is %v.", resource, klog.KRef(e.vpaKey.Namespace, e.vpaKey.VpaName), resourceAmount, e.minResources[resource])
+			if resource == "memory" && resourceAmount == 0 && e.estimatorName == targetEstimatorName {
+				klog.Warningf("Computed %q resources for VPA %q were below minimum in min resource estimator of %q! Computed %v, minimum is %v.", resource, klog.KRef(e.vpaKey.Namespace, e.vpaKey.VpaName), e.estimatorName, resourceAmount, e.minResources[resource])
 				logHistogramInformation(s, e.vpaKey)
-				metrics_quality.ObserveLowerThanMinRecommendation(s.GetUpdateMode(), corev1.ResourceName(resource), e.vpaKey.Namespace+"/"+e.vpaKey.VpaName)
+				metricsquality.ObserveLowerThanMinRecommendation(s.GetUpdateMode(), corev1.ResourceName("memory"), e.vpaKey.Namespace+"/"+e.vpaKey.VpaName)
 			}
 			resourceAmount = e.minResources[resource]
 		}
@@ -170,20 +220,33 @@ func (e *minResourcesEstimator) GetResourceEstimation(s *model.AggregateContaine
 	return newResources
 }
 
+func (e *minResourcesEstimator) SetVpaKeyAndEstimatorName(vpaKey model.VpaID, estimatorName string) {
+	e.vpaKey = vpaKey
+	e.estimatorName = estimatorName
+	e.baseEstimator.SetVpaKeyAndEstimatorName(vpaKey, estimatorName)
+}
+
 func logHistogramInformation(s *model.AggregateContainerState, vpaKey model.VpaID) {
 	if s.AggregateCPUUsage == nil {
-		klog.Warning("Aggregate CPU usage has no metric samples, cannot show internal histogram data for VPA %s!", klog.KRef(vpaKey.Namespace, vpaKey.VpaName))
+		klog.Warning("Aggregate CPU usage has no metric samples, cannot show internal histogram data for VPA %q!", klog.KRef(vpaKey.Namespace, vpaKey.VpaName))
 		return
 	}
 	if s.AggregateMemoryPeaks == nil {
-		klog.Warning("Aggregate memory usage has no metric samples, cannot show internal histogram data for VPA %s!", klog.KRef(vpaKey.Namespace, vpaKey.VpaName))
+		klog.Warning("Aggregate memory usage has no metric samples, cannot show internal histogram data for VPA %q!", klog.KRef(vpaKey.Namespace, vpaKey.VpaName))
 		return
 	}
+
+	if s.AggregateMemoryPeaks.IsEmpty() {
+		klog.Warningf("The memory histogram for VPA %q is empty!", klog.KRef(vpaKey.Namespace, vpaKey.VpaName))
+	}
+
+	klog.Warningf("Here's the string representation of the memory histogram for VPA %q: %s", klog.KRef(vpaKey.Namespace, vpaKey.VpaName), s.AggregateMemoryPeaks.String())
+
 	c, _ := s.SaveToCheckpoint()
-	prettyCheckpoint, err := json.MarshalIndent(c, "", "  ")
+	prettyCheckpoint, err := json.Marshal(c)
 	if err != nil {
-		klog.Errorf("Error during marshalling checkpoint for VPA %s: %s", klog.KRef(vpaKey.Namespace, vpaKey.VpaName), err)
+		klog.Errorf("Error during marshalling checkpoint for VPA %q: %s", klog.KRef(vpaKey.Namespace, vpaKey.VpaName), err)
 		return
 	}
-	klog.Warningf("Here's the checkpoint/state for VPA %s: %s", klog.KRef(vpaKey.Namespace, vpaKey.VpaName), prettyCheckpoint)
+	klog.Warningf("Here's the checkpoint/state for VPA %q: %s", klog.KRef(vpaKey.Namespace, vpaKey.VpaName), prettyCheckpoint)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -106,8 +106,8 @@ func TestConfidenceMultiplierNoHistory(t *testing.T) {
 		model.ResourceCPU:    model.CPUAmountFromCores(3.14),
 		model.ResourceMemory: model.MemoryAmountFromBytes(3.14e9),
 	})
-	testedEstimator1 := &confidenceMultiplier{1.0, 1.0, baseEstimator}
-	testedEstimator2 := &confidenceMultiplier{1.0, -1.0, baseEstimator}
+	testedEstimator1 := &confidenceMultiplier{multiplier: 1.0, exponent: 1.0, baseEstimator: baseEstimator}
+	testedEstimator2 := &confidenceMultiplier{multiplier: 1.0, exponent: -1.0, baseEstimator: baseEstimator}
 	s := model.NewAggregateContainerState()
 	// Expect testedEstimator1 to return the maximum possible resource amount.
 	assert.Equal(t, model.ResourceAmount(1e14),

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -74,10 +74,14 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 	}
 
 	recommender := &podResourceRecommender{
-		WithMinResources(minResources, r.targetEstimator, vpaKey),
-		WithMinResources(minResources, r.lowerBoundEstimator, vpaKey),
-		WithMinResources(minResources, r.upperBoundEstimator, vpaKey),
+		WithMinResources(minResources, r.targetEstimator),
+		WithMinResources(minResources, r.lowerBoundEstimator),
+		WithMinResources(minResources, r.upperBoundEstimator),
 	}
+
+	recommender.targetEstimator.SetVpaKeyAndEstimatorName(vpaKey, targetEstimatorName)
+	recommender.upperBoundEstimator.SetVpaKeyAndEstimatorName(vpaKey, upperBoundEstimatorName)
+	recommender.lowerBoundEstimator.SetVpaKeyAndEstimatorName(vpaKey, lowerBoundEstimatorName)
 
 	for containerName, aggregatedContainerState := range containerNameToAggregateStateMap {
 		recommendation[containerName] = recommender.estimateContainerResources(aggregatedContainerState)

--- a/vertical-pod-autoscaler/pkg/recommender/util/decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/decaying_histogram.go
@@ -94,7 +94,7 @@ func (h *decayingHistogram) IsEmpty() bool {
 }
 
 func (h *decayingHistogram) String() string {
-	return fmt.Sprintf("referenceTimestamp: %v, halfLife: %v\n%s", h.referenceTimestamp, h.halfLife, h.histogram.String())
+	return fmt.Sprintf("referenceTimestamp: %v, halfLife: %v; %s", h.referenceTimestamp, h.halfLife, h.histogram.String())
 }
 
 func (h *decayingHistogram) shiftReferenceTimestamp(newreferenceTimestamp time.Time) {

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -184,14 +184,20 @@ func (h *histogram) IsEmpty() bool {
 
 func (h *histogram) String() string {
 	lines := []string{
-		fmt.Sprintf("minBucket: %d, maxBucket: %d, totalWeight: %.3f",
+		fmt.Sprintf("minBucket: %d, maxBucket: %d, totalWeight: %.4f",
 			h.minBucket, h.maxBucket, h.totalWeight),
-		"%-tile\tvalue",
+		"%-tile value: ",
 	}
 	for i := 0; i <= 100; i += 5 {
-		lines = append(lines, fmt.Sprintf("%d\t%.3f", i, h.Percentile(0.01*float64(i))))
+		lines = append(lines, fmt.Sprintf("%d: %.4f", i, h.Percentile(0.01*float64(i))))
 	}
-	return strings.Join(lines, "\n")
+
+	lines = append(lines, "buckets value")
+	for i := 0; i < h.options.NumBuckets(); i++ {
+		lines = append(lines, fmt.Sprintf("%d: %.4f", i, h.bucketWeight[i]))
+	}
+
+	return strings.Join(lines, "; ")
 }
 
 func (h *histogram) Equals(other Histogram) bool {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR further enhances logging added in #322  in cases where `vpa-recommender` recommends 0 memory resources. I have chosen to only log cases when recommendations are 0 as these are the recommendations that we have observed when the issue occurs.

Here are the enhancements:
- The internal histogram representation will be printed when 0 recommendations occur
- Recommendations of each estimator are printed, not only the last one in the chain 
- Logging is only done when the target estimator recommends 0 memory to reduce amounts of logs - no logs are printed for lower bound and upper bound estimators
- The histogram and checkpoint will be printed on single lines so that they can be easily identified in plutono and not be mixed up with other log lines

Here's what an example log would look like:
```
W1017 16:24:46.291415   92393 estimator.go:133] Computed "memory" resources for VPA "foo/bar" were 0 in percentile estimator of "targetEstimator"!
W1017 16:24:46.291842   92393 estimator.go:194] Computed "memory" resources for VPA "foo/bar" were 0 after applying margin in margin estimator of "targetEstimator", they were 0 before that
W1017 16:24:46.291864   92393 estimator.go:212] Computed "memory" resources for VPA "foo/bar" were below minimum in min resource estimator of "targetEstimator"! Computed 0, minimum is 400000000.
W1017 16:24:46.291916   92393 estimator.go:240] The memory histogram for VPA "foo/bar" is empty!
W1017 16:24:46.291998   92393 estimator.go:243] Here's the string representation of the memory histogram for VPA "foo/bar": referenceTimestamp: 0001-01-01 00:00:00 +0000 UTC, halfLife: 24h0m0s; minBucket: 175, maxBucket: 0, totalWeight: 0.0000; %-tile value: ; 0: 0.0000; 5: 0.0000; 10: 0.0000; 15: 0.0000; 20: 0.0000; 25: 0.0000; 30: 0.0000; 35: 0.0000; 40: 0.0000; 45: 0.0000; 50: 0.0000; 55: 0.0000; 60: 0.0000; 65: 0.0000; 70: 0.0000; 75: 0.0000; 80: 0.0000; 85: 0.0000; 90: 0.0000; 95: 0.0000; 100: 0.0000; buckets value; 0: 0.0000; 1: 0.0000; 2: 0.0000; 3: 0.0000; 4: 0.0000; 5: 0.0000; 6: 0.0000; 7: 0.0000; 8: 0.0000; 9: 0.0000; 10: 0.0000; 11: 0.0000; 12: 0.0000; 13: 0.0000; 14: 0.0000; 15: 0.0000; 16: 0.0000; 17: 0.0000; 18: 0.0000; 19: 0.0000; 20: 0.0000; 21: 0.0000; 22: 0.0000; 23: 0.0000; 24: 0.0000; 25: 0.0000; 26: 0.0000; 27: 0.0000; 28: 0.0000; 29: 0.0000; 30: 0.0000; 31: 0.0000; 32: 0.0000; 33: 0.0000; 34: 0.0000; 35: 0.0000; 36: 0.0000; 37: 0.0000; 38: 0.0000; 39: 0.0000; 40: 0.0000; 41: 0.0000; 42: 0.0000; 43: 0.0000; 44: 0.0000; 45: 0.0000; 46: 0.0000; 47: 0.0000; 48: 0.0000; 49: 0.0000; 50: 0.0000; 51: 0.0000; 52: 0.0000; 53: 0.0000; 54: 0.0000; 55: 0.0000; 56: 0.0000; 57: 0.0000; 58: 0.0000; 59: 0.0000; 60: 0.0000; 61: 0.0000; 62: 0.0000; 63: 0.0000; 64: 0.0000; 65: 0.0000; 66: 0.0000; 67: 0.0000; 68: 0.0000; 69: 0.0000; 70: 0.0000; 71: 0.0000; 72: 0.0000; 73: 0.0000; 74: 0.0000; 75: 0.0000; 76: 0.0000; 77: 0.0000; 78: 0.0000; 79: 0.0000; 80: 0.0000; 81: 0.0000; 82: 0.0000; 83: 0.0000; 84: 0.0000; 85: 0.0000; 86: 0.0000; 87: 0.0000; 88: 0.0000; 89: 0.0000; 90: 0.0000; 91: 0.0000; 92: 0.0000; 93: 0.0000; 94: 0.0000; 95: 0.0000; 96: 0.0000; 97: 0.0000; 98: 0.0000; 99: 0.0000; 100: 0.0000; 101: 0.0000; 102: 0.0000; 103: 0.0000; 104: 0.0000; 105: 0.0000; 106: 0.0000; 107: 0.0000; 108: 0.0000; 109: 0.0000; 110: 0.0000; 111: 0.0000; 112: 0.0000; 113: 0.0000; 114: 0.0000; 115: 0.0000; 116: 0.0000; 117: 0.0000; 118: 0.0000; 119: 0.0000; 120: 0.0000; 121: 0.0000; 122: 0.0000; 123: 0.0000; 124: 0.0000; 125: 0.0000; 126: 0.0000; 127: 0.0000; 128: 0.0000; 129: 0.0000; 130: 0.0000; 131: 0.0000; 132: 0.0000; 133: 0.0000; 134: 0.0000; 135: 0.0000; 136: 0.0000; 137: 0.0000; 138: 0.0000; 139: 0.0000; 140: 0.0000; 141: 0.0000; 142: 0.0000; 143: 0.0000; 144: 0.0000; 145: 0.0000; 146: 0.0000; 147: 0.0000; 148: 0.0000; 149: 0.0000; 150: 0.0000; 151: 0.0000; 152: 0.0000; 153: 0.0000; 154: 0.0000; 155: 0.0000; 156: 0.0000; 157: 0.0000; 158: 0.0000; 159: 0.0000; 160: 0.0000; 161: 0.0000; 162: 0.0000; 163: 0.0000; 164: 0.0000; 165: 0.0000; 166: 0.0000; 167: 0.0000; 168: 0.0000; 169: 0.0000; 170: 0.0000; 171: 0.0000; 172: 0.0000; 173: 0.0000; 174: 0.0000; 175: 0.0000
W1017 16:24:46.292089   92393 estimator.go:251] Here's the checkpoint/state for VPA "foo/bar": {"lastUpdateTime":"2024-10-17T13:24:46Z","version":"v3","cpuHistogram":{"referenceTimestamp":null},"memoryHistogram":{"referenceTimestamp":null},"firstSampleStart":null,"lastSampleStart":null}
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @voelzmo @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Enhance logging in case we have 0 memory recommendations.
```
