### PR TITLE
Use manual version handling to better indicate fork builds

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -118,7 +118,7 @@ vertical-pod-autoscaler:
     release:
       traits:
         version:
-          preprocess: 'finalize'
+          preprocess: 'noop'
         component_descriptor:
           ocm_repository: europe-docker.pkg.dev/gardener-project/releases
         publish:
@@ -130,7 +130,7 @@ vertical-pod-autoscaler:
             vpa-admission-controller:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/vertical-pod-autoscaler/vpa-admission-controller
         release:
-          nextversion: 'bump_minor'
+          nextversion: 'noop'
           git_tags:
             - ref_template: refs/tags/vpa-{VERSION}
           on_tag_conflict: 'fail'

--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.3.0-dev"
+const VerticalPodAutoscalerVersion = "1.2.1-gardener-build.2"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR changes the version of VPA to `1.2.1-gardener-build.2` and disables automatic version handling, so that we can manually bump the build number. E.g. the next version would be `1.2.1-gardener-build.3` and so on. When updating VPA from the upstream branch the major, minor and patch versions would have to be manually updated, e.g. to 1.3.0-gardener-build.1

Sadly, this cannot be handled with the current available API of [cc-utils](https://gardener.github.io/cc-utils) so we will have to maintain the version manually.
This is done so that we can better differentiate between builds of the upstream VPA and builds from our forked branch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ccwienk @ialidzhikov @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
