### PR TITLE
Increase precision of histogram logs and bump version suffix

### DIFF
--- a/vertical-pod-autoscaler/common/version.go
+++ b/vertical-pod-autoscaler/common/version.go
@@ -17,4 +17,4 @@ limitations under the License.
 package common
 
 // VerticalPodAutoscalerVersion is the version of VPA.
-const VerticalPodAutoscalerVersion = "1.2.1-gardener-build.2"
+const VerticalPodAutoscalerVersion = "1.2.1-gardener-build.3"

--- a/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/histogram.go
@@ -184,17 +184,17 @@ func (h *histogram) IsEmpty() bool {
 
 func (h *histogram) String() string {
 	lines := []string{
-		fmt.Sprintf("minBucket: %d, maxBucket: %d, totalWeight: %.4f",
+		fmt.Sprintf("minBucket: %d, maxBucket: %d, totalWeight: %g",
 			h.minBucket, h.maxBucket, h.totalWeight),
 		"%-tile value: ",
 	}
 	for i := 0; i <= 100; i += 5 {
-		lines = append(lines, fmt.Sprintf("%d: %.4f", i, h.Percentile(0.01*float64(i))))
+		lines = append(lines, fmt.Sprintf("%d: %g", i, h.Percentile(0.01*float64(i))))
 	}
 
 	lines = append(lines, "buckets value")
 	for i := 0; i < h.options.NumBuckets(); i++ {
-		lines = append(lines, fmt.Sprintf("%d: %.4f", i, h.bucketWeight[i]))
+		lines = append(lines, fmt.Sprintf("%d: %g", i, h.bucketWeight[i]))
 	}
 
 	return strings.Join(lines, "; ")


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR increases the precision with which floating points are printed when logging the internal state of the histogram.
With the changes the logs would look like this:


> referenceTimestamp: 2009-05-26 03:00:00 +0300 EEST, halfLife: 24h0m0s; minBucket: 88, maxBucket: 101, totalWeight: 1.97275026472799; %-tile value: ; 0: 0; 5: 0; 10: 0; 15: 0; 20: 0; 25: 0; 30: 0; 35: 0; 40: 0; 45: 0; 50: 0; 55: 0; 60: 0; 65: 0; 70: 0; 75: 0; 80: 0; 85: 0; 90: 0; 95: 0; 100: 0; buckets value; 0: 0; 1: 0; 2: 0; 3: 0; 4: 0; 5: 0; 6: 0; 7: 0; 8: 0; 9: 0; 10: 0; 11: 0; 12: 0; 13: 0; 14: 0; 15: 0; 16: 0; 17: 0; 18: 0; 19: 0; 20: 0; 21: 0; 22: 0; 23: 0; 24: 0; 25: 0; 26: 0; 27: 0; 28: 0; 29: 0; 30: 0; 31: 0; 32: 0; 33: 0; 34: 0; 35: 0; 36: 0; 37: 0; 38: 0; 39: 0; 40: 0; 41: 0; 42: 0; 43: 0; 44: 0; 45: 0; 46: 0; 47: 0; 48: 0; 49: 0; 50: 0; 51: 0; 52: 0; 53: 0; 54: 0; 55: 0; 56: 0; 57: 0; 58: 0; 59: 0; 60: 0; 61: 0; 62: 0; 63: 0; 64: 0; 65: 0; 66: 0; 67: 0; 68: 0; 69: 0; 70: 0; 71: 0; 72: 0; 73: 0; 74: 0; 75: 0; 76: 0; 77: 0; 78: 0; 79: 0; 80: 0; 81: 0; 82: 0; 83: 0; 84: 0; 85: 0; 86: 0; 87: 0; 88: 9.864244535866743e-05; 89: 0.00019728489071733487; 90: 0.0004932122267933372; 91: 0.0009864244535866744; 92: 0.0019728489071733487; 93: 0.00384705536898803; 94: 0.00769411073797606; 95: 0.01538822147595212; 96: 0.030875085397262907; 97: 0.061651528349167144; 98: 0.12330305669833429; 99: 0.24660611339666857; 100: 0.49321222679333715; 101: 0.9864244535866743; 102: 0; 103: 0; 104: 0; 105: 0; 106: 0; 107: 0; 108: 0; 109: 0; 110: 0; 111: 0; 112: 0; 113: 0; 114: 0; 115: 0; 116: 0; 117: 0; 118: 0; 119: 0; 120: 0; 121: 0; 122: 0; 123: 0; 124: 0; 125: 0; 126: 0; 127: 0; 128: 0; 129: 0; 130: 0; 131: 0; 132: 0; 133: 0; 134: 0; 135: 0; 136: 0; 137: 0; 138: 0; 139: 0; 140: 0; 141: 0; 142: 0; 143: 0; 144: 0; 145: 0; 146: 0; 147: 0; 148: 0; 149: 0; 150: 0; 151: 0; 152: 0; 153: 0; 154: 0; 155: 0; 156: 0; 157: 0; 158: 0; 159: 0; 160: 0; 161: 0; 162: 0; 163: 0; 164: 0; 165: 0; 166: 0; 167: 0; 168: 0; 169: 0; 170: 0; 171: 0; 172: 0; 173: 0; 174: 0; 175: 0


Previously, only the first 4 digits were printed which were not enough to see the exact number of histogram weights if they were below 0.0001 (epsilon)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @ialidzhikov @voelzmo 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The precision for floating point numbers in logs is now increased.
```
