### PR TITLE
./hack/launch-local-ca.sh for dev productivity

### DIFF
--- a/cluster-autoscaler/.gitignore
+++ b/cluster-autoscaler/.gitignore
@@ -12,3 +12,5 @@ Session.vim
 .netrwhist
 .vscode
 ./integration/logs
+.env
+integration/logs/autoscaler_processs.log

--- a/cluster-autoscaler/hack/launch-local-ca.sh
+++ b/cluster-autoscaler/hack/launch-local-ca.sh
@@ -1,4 +1,20 @@
 #!/usr/bin/env zsh
+# /*
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# */
+#
 set -eo pipefail
 
 echoErr() { echo "$@" 1>&2; }

--- a/cluster-autoscaler/hack/launch-local-ca.sh
+++ b/cluster-autoscaler/hack/launch-local-ca.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env zsh
+set -eo pipefail
+
+echoErr() { echo "$@" 1>&2; }
+
+
+CURRENT_DIR=$(pwd)
+PROJECT_ROOT="${CURRENT_DIR}"
+
+if  ! command -v gum &>/dev/null; then
+  echoErr "gum not installed. Kindly first install gum (https://github.com/charmbracelet/gum) using relevant procedure for your OS"
+  exit 1
+fi
+
+devEnvFile="$PROJECT_ROOT/.env"
+if [[ ! -f "$devEnvFile" ]]; then
+  echoErr  "ERROR: $devEnvFile is not created. Kindly execute ./hack/local_setup.sh before running this script."
+  exit 2
+fi
+
+source "$devEnvFile"
+
+if [[ ! -f "$CONTROL_KUBECONFIG" ]]; then
+  echoErr  "ERROR: Control Cluster kubeconfig is not at expected path $CONTROL_KUBECONFIG. Please ensure that ./hack/local_setup.sh is run correctly."
+  exit 3
+fi
+
+if [[ -z "$GARDEN_PROJECT" ]]; then
+  echoErr  "ERROR: GARDEN_PROJECT env-var not set. Please ensure that ./hack/local_setup.sh is run correctly and check $devEnvFile.."
+  exit 4
+fi
+
+if [[ -z "$SHOOT" ]]; then
+  echoErr  "ERROR: SHOOT env-var not set. Please ensure that ./hack/local_setup.sh is run correctly and check $devEnvFile."
+  exit 5
+fi
+
+if [[ ! -f "main.go" ]]; then
+  echoErr "ERROR: CA main.go missing in current dir. Please ensure you are in the right cluster-autoscaler dir."
+  exit 6
+fi
+
+echo "NOTE: This script generates a /tmp/local-ca.sh which launches the local CA with the same configuration as that of the remote CA in the configured shoot's control plane"
+
+echo "Targeting control plane of sap-landscape-dev:$GARDEN_PROJECT:$SHOOT"
+gardenctl target --garden sap-landscape-dev --project "$GARDEN_PROJECT" --shoot aw --control-plane
+caDeploJsonPath="/tmp/ca-deploy.json"
+kubectl get deploy cluster-autoscaler -ojson > "$caDeploJsonPath"
+echo "Downloaded CA Deployment JSON YAML into $caDeploJsonPath"
+
+commandArgs=$(jq -r '.spec.template.spec.containers[0].command[]' "$caDeploJsonPath" | sed 1d | sed /--kubeconfig/d | tr '\n' ' ')
+export CONTROL_KUBECONFIG="$CONTROL_KUBECONFIG"
+export CONTROL_NAMESPACE="$CONTROL_NAMESPACE"
+export TARGET_KUBECONFIG="$TARGET_KUBECONFIG"
+launchCommand="go run main.go --kubeconfig=$TARGET_KUBECONFIG $commandArgs 2>&1 | tee /tmp/ca.log"
+gum confirm "Launch local CA using following command: '$launchCommand' ?" && echo "$launchCommand" && eval "$launchCommand"
+
+

--- a/cluster-autoscaler/hack/local_setup.sh
+++ b/cluster-autoscaler/hack/local_setup.sh
@@ -48,6 +48,11 @@ GARDEN_NAMESPACE=garden
 gardenctl target --garden sap-landscape-dev
 eval $(gardenctl kubectl-env bash)
 
+if [[ ! -d "$KUBECONFIG_PATH" ]]; then
+  mkdir -p "$KUBECONFIG_PATH"
+  echo "Created dirs $KUBECONFIG_PATH"
+fi
+
 #setting kubeconfig of control cluster
 
 echo "$(kubectl create -f $PROJECT_ROOT/hack/kubeconfig-request.json --raw /apis/core.gardener.cloud/v1beta1/namespaces/${GARDEN_NAMESPACE}/shoots/${SEED}/adminkubeconfig | jq -r ".status.kubeconfig" | base64 -d)" >  $KUBECONFIG_PATH/kubeconfig_control.yaml
@@ -63,3 +68,16 @@ echo "kubeconfigs have been downloaded and kept at /dev/kubeconfigs/kubeconfig_<
 export CONTROL_NAMESPACE=shoot--$PROJECT--$SHOOT
 export CONTROL_KUBECONFIG=$KUBECONFIG_PATH/kubeconfig_control.yaml
 export TARGET_KUBECONFIG=$KUBECONFIG_PATH/kubeconfig_target.yaml
+
+devEnvFile="$PROJECT_ROOT/.env"
+cat << EOF >"$devEnvFile"
+CONTROL_NAMESPACE="$CONTROL_NAMESPACE"
+CONTROL_KUBECONFIG="$CONTROL_KUBECONFIG"
+TARGET_KUBECONFIG="$TARGET_KUBECONFIG"
+PROJECT_ROOT="$PROJECT_ROOT"
+GARDEN_PROJECT="$PROJECT"
+GARDEN_PROJECT_NAMESPACE="$NAMESPACE"
+SHOOT="$SHOOT"
+EOF
+
+echo "Wrote $devEnvFile"


### PR DESCRIPTION
**What this PR does / why we need it**:

This change is to assist developer productivity by providing a local CA launch script that copies its configuration from the gardener shoot CA in the control plane avoiding the necessity of developer painfully copying CA flags and making their custom script.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
