### PR TITLE
[Cherry-pick rel-v1.30] Handle edge case as described in issue #328 (#335)

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -225,20 +225,11 @@ func (mcm *mcmCloudProvider) checkMCMAvailableReplicas() error {
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 func (mcm *mcmCloudProvider) Refresh() error {
-
 	err := mcm.checkMCMAvailableReplicas()
 	if err != nil {
 		return err
 	}
-
-	for _, machineDeployment := range mcm.machinedeployments {
-		err := mcm.mcmManager.resetPriorityForNotToBeDeletedMachines(machineDeployment.Name)
-		if err != nil {
-			klog.Errorf("failed to reset priority for machines in MachineDeployment %s, err: %v", machineDeployment.Name, err.Error())
-			return err
-		}
-	}
-	return nil
+	return mcm.mcmManager.Refresh()
 }
 
 // GPULabel returns the label added to nodes with GPU resource.

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -30,9 +30,8 @@ import (
 )
 
 var (
-	testNamespace         = "test-namespace"
-	priorityAnnotationKey = "machinepriority.machine.sapcloud.io"
-	testTaintValue        = fmt.Sprint(time.Now().Unix())
+	testNamespace  = "test-namespace"
+	testTaintValue = fmt.Sprint(time.Now().Unix())
 )
 
 func newMachineDeployments(
@@ -135,7 +134,7 @@ func newMachines(
 					{Name: msName},
 				},
 				Labels:            map[string]string{machineDeploymentNameLabel: mdName},
-				Annotations:       map[string]string{priorityAnnotationKey: priorityAnnotationValues[i]},
+				Annotations:       map[string]string{machinePriorityAnnotation: priorityAnnotationValues[i]},
 				CreationTimestamp: metav1.Now(),
 			},
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cherry-pick of #335  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
IT passed on k8s 1.30.5 AWS cluster

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Refresh method resets the priority annotation on machines with priority 1 to match the desired count. Refer to the PR for details on how the desired count is calculated.
```
