### PR TITLE
Fix Race conditions in Targeted Deletion of machines by CA

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -25,7 +25,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
-	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -569,7 +568,10 @@ func mergeStringSlicesUnique(slice1, slice2 []string) []string {
 	for _, s := range slices.Concat(slice1, slice2) {
 		seen[s] = struct{}{}
 	}
-	concatenated := slices.Collect(maps.Keys(seen))
+	concatenated := make([]string, 0, len(seen)) // TODO: Change to slices.Collect(maps.Keys(seen)) from Go 1.23
+	for s := range seen {
+		concatenated = append(concatenated, s)
+	}
 	slices.Sort(concatenated)
 	return concatenated
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -135,7 +135,7 @@ func (mcm *mcmCloudProvider) NodeGroupForNode(node *apiv1.Node) (cloudprovider.N
 		return nil, nil
 	}
 
-	mInfo, err := mcm.mcmManager.GetMachineInfo(node)
+	mInfo, err := mcm.mcmManager.getMachineInfo(node)
 	if err != nil {
 		return nil, err
 	}
@@ -360,7 +360,7 @@ func (ngImpl *NodeGroupImpl) Refresh() error {
 
 // Belongs checks if the given node belongs to this NodeGroup and also returns its MachineInfo for its corresponding Machine
 func (ngImpl *NodeGroupImpl) Belongs(node *apiv1.Node) (belongs bool, mInfo *machineInfo, err error) {
-	mInfo, err = ngImpl.mcmManager.GetMachineInfo(node)
+	mInfo, err = ngImpl.mcmManager.getMachineInfo(node)
 	if err != nil || mInfo == nil {
 		return
 	}
@@ -575,18 +575,6 @@ func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []stri
 
 // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
 func createMachinesTriggeredForDeletionAnnotValue(machineNames []string) string {
+	slices.Sort(machineNames)
 	return strings.Join(machineNames, ",")
-}
-
-func mergeStringSlicesUnique(slice1, slice2 []string) []string {
-	seen := make(map[string]struct{}, len(slice1)+len(slice2))
-	for _, s := range slices.Concat(slice1, slice2) {
-		seen[s] = struct{}{}
-	}
-	concatenated := make([]string, 0, len(seen)) // TODO: Change to slices.Collect(maps.Keys(seen)) from Go 1.23
-	for s := range seen {
-		concatenated = append(concatenated, s)
-	}
-	slices.Sort(concatenated)
-	return concatenated
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -207,10 +207,10 @@ func (mcm *mcmCloudProvider) checkMCMAvailableReplicas() error {
 // Refresh is called before every main loop and can be used to dynamically update cloud provider state.
 // In particular the list of node groups returned by NodeGroups can change as a result of CloudProvider.Refresh().
 func (mcm *mcmCloudProvider) Refresh() error {
-	//err := mcm.checkMCMAvailableReplicas()
-	//if err != nil {
-	//	return err
-	//}
+	err := mcm.checkMCMAvailableReplicas()
+	if err != nil {
+		return err
+	}
 	return mcm.mcmManager.Refresh()
 }
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -437,6 +437,7 @@ func (ngImpl *NodeGroupImpl) deleteMachines(toDeleteMachineInfos []machineInfo) 
 	return nil
 }
 
+// AcquireScalingMutex acquires the scalingMutex associated with this NodeGroup and returns a function that releases the scalingMutex that is expected to be deferred by the caller.
 func (ngImpl *NodeGroupImpl) AcquireScalingMutex(operation string) (releaseFn func()) {
 	klog.V(3).Infof("%s is acquired scalingMutex for NodeGroup %q", operation, ngImpl.Name)
 	ngImpl.scalingMutex.Lock()

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -284,7 +284,7 @@ func (ngImpl *NodeGroupImpl) IncreaseSize(delta int) error {
 	if delta <= 0 {
 		return fmt.Errorf("size increase must be positive")
 	}
-	release := ngImpl.AcquireScalingMutex("IncreaseSize")
+	release := ngImpl.AcquireScalingMutex(fmt.Sprintf("IncreaseSize by #%d", delta))
 	defer release()
 	size, err := ngImpl.mcmManager.GetMachineDeploymentSize(ngImpl.Name)
 	if err != nil {
@@ -309,7 +309,7 @@ func (ngImpl *NodeGroupImpl) DecreaseTargetSize(delta int) error {
 	if delta >= 0 {
 		return fmt.Errorf("size decrease size must be negative")
 	}
-	release := ngImpl.AcquireScalingMutex("DecreaseTargetSize")
+	release := ngImpl.AcquireScalingMutex(fmt.Sprintf("DecreaseTargetSize by #%d", delta))
 	defer release()
 	size, err := ngImpl.mcmManager.GetMachineDeploymentSize(ngImpl.Name)
 	if err != nil {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -352,12 +352,12 @@ func (ngImpl *NodeGroupImpl) Refresh() error {
 }
 
 // Belongs checks if the given node belongs to this NodeGroup and also returns its MachineInfo for its corresponding Machine
-func (ngImpl *NodeGroupImpl) Belongs(node *apiv1.Node) (belongs bool, machineInfo *MachineInfo, err error) {
-	machineInfo, err = ngImpl.mcmManager.GetMachineInfo(node)
-	if err != nil || machineInfo == nil {
+func (ngImpl *NodeGroupImpl) Belongs(node *apiv1.Node) (belongs bool, mInfo *machineInfo, err error) {
+	mInfo, err = ngImpl.mcmManager.GetMachineInfo(node)
+	if err != nil || mInfo == nil {
 		return
 	}
-	targetMd, err := ngImpl.mcmManager.GetNodeGroupImpl(machineInfo.Key)
+	targetMd, err := ngImpl.mcmManager.GetNodeGroupImpl(mInfo.Key)
 	if err != nil {
 		return
 	}
@@ -382,7 +382,7 @@ func (ngImpl *NodeGroupImpl) DeleteNodes(nodes []*apiv1.Node) error {
 	if int(size) <= ngImpl.MinSize() {
 		return fmt.Errorf("min size reached, nodes will not be deleted")
 	}
-	var toDeleteMachineInfos []MachineInfo
+	var toDeleteMachineInfos []machineInfo
 	for _, node := range nodes {
 		belongs, machineInfo, err := ngImpl.Belongs(node)
 		if err != nil {
@@ -400,7 +400,7 @@ func (ngImpl *NodeGroupImpl) DeleteNodes(nodes []*apiv1.Node) error {
 }
 
 // deleteMachines annotates the corresponding MachineDeployment with machine names of toDeleteMachineInfos, reduces the desired replicas of the corresponding MachineDeployment and cordons corresponding nodes belonging to toDeleteMachineInfos
-func (ngImpl *NodeGroupImpl) deleteMachines(toDeleteMachineInfos []MachineInfo) error {
+func (ngImpl *NodeGroupImpl) deleteMachines(toDeleteMachineInfos []machineInfo) error {
 	if len(toDeleteMachineInfos) == 0 {
 		return nil
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -341,8 +341,8 @@ func (ngImpl *nodeGroup) Refresh() error {
 	}
 	machinesOfNodeGroup, err := ngImpl.mcmManager.getMachinesForMachineDeployment(ngImpl.Name)
 	if err != nil {
-		klog.Errorf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
-		return fmt.Errorf("failed refresh of NodeGroup %q due to: %v", ngImpl.Name, err)
+		klog.Warningf("NodeGroup.Refresh() of %q failed to get machines for MachineDeployment due to: %v", ngImpl.Name, err)
+		return nil
 	}
 	toBeDeletedMachines := filterMachinesMatchingNames(machinesOfNodeGroup, sets.New(toBeDeletedMachineNames...))
 	if len(toBeDeletedMachines) == 0 {
@@ -479,7 +479,7 @@ func getNodeNamesFromMachines(machines []*v1alpha1.Machine) []string {
 	return nodeNames
 }
 
-// Id returns MachineDeployment id.
+// Id returns NodeGroup name
 func (ngImpl *nodeGroup) Id() string {
 	return ngImpl.Name
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -581,7 +581,7 @@ func TestGetOptions(t *testing.T) {
 				nodeGroups: []string{nodeGroup1},
 			},
 			expect{
-				err: fmt.Errorf("unable to fetch MachineDeployment object machinedeployment-1, Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
+				err: fmt.Errorf("unable to fetch MachineDeployment object \"machinedeployment-1\", Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
 			},
 		},
 		{

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -153,7 +153,7 @@ func TestDeleteNodes(t *testing.T) {
 				prio1Machines: nil,
 				mdName:        "machinedeployment-1",
 				mdReplicas:    2,
-				err:           fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
+				err:           fmt.Errorf("NodeGroupImpl machinedeployment-1 is under rolling update , cannot reduce replica count"),
 			},
 		},
 		{
@@ -309,7 +309,7 @@ func TestDeleteNodes(t *testing.T) {
 				trackers.ControlMachine.SetFailAtFakeResourceActions(entry.setup.controlMachineFakeResourceActions)
 			}
 
-			md, err := buildMachineDeploymentFromSpec(entry.setup.nodeGroups[0], m)
+			md, err := buildNodeGroupImplFromSpec(entry.setup.nodeGroups[0], m)
 			g.Expect(err).To(BeNil())
 
 			err = md.DeleteNodes([]*corev1.Node{entry.action.node})
@@ -323,7 +323,7 @@ func TestDeleteNodes(t *testing.T) {
 			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
-			g.Expect(machineDeployment.Annotations[machinesMarkedByCAForDeletion]).To(Equal(entry.expect.machinesMarkedByCAAnnotationValue))
+			g.Expect(machineDeployment.Annotations[machinesMarkedByCAForDeletionAnnotation]).To(Equal(entry.expect.machinesMarkedByCAAnnotationValue))
 
 			machines, err := m.machineClient.Machines(m.namespace).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
@@ -359,7 +359,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, setupObj.nodeGroups, controlMachineObjects, targetCoreObjects, nil)
 	defer trackers.Stop()
 	waitForCacheSync(t, stop, hasSyncedCacheFns)
-	md, err := buildMachineDeploymentFromSpec(setupObj.nodeGroups[0], m)
+	md, err := buildNodeGroupImplFromSpec(setupObj.nodeGroups[0], m)
 	g.Expect(err).To(BeNil())
 
 	err = md.DeleteNodes(newNodes(1, "fakeID"))
@@ -370,7 +370,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), setupObj.machineDeployments[0].Name, metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", 2))
-	g.Expect(machineDeployment.Annotations[machinesMarkedByCAForDeletion]).To(Equal(createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1))))
+	g.Expect(machineDeployment.Annotations[machinesMarkedByCAForDeletionAnnotation]).To(Equal(createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1))))
 }
 
 func TestRefresh(t *testing.T) {
@@ -429,7 +429,7 @@ func TestRefresh(t *testing.T) {
 			setup{
 				nodes:              newNodes(1, "fakeID"),
 				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machineDeployments: newMachineDeployments(1, 0, nil, map[string]string{machinesMarkedByCAForDeletion: "machine-1,machine-2"}, nil),
+				machineDeployments: newMachineDeployments(1, 0, nil, map[string]string{machinesMarkedByCAForDeletionAnnotation: "machine-1,machine-2"}, nil),
 				nodeGroups:         []string{nodeGroup2},
 				mcmDeployment:      newMCMDeployment(1),
 			},
@@ -581,7 +581,7 @@ func TestNodes(t *testing.T) {
 				trackers.ControlMachine.SetFailAtFakeResourceActions(entry.setup.controlMachineFakeResourceActions)
 			}
 
-			md, err := buildMachineDeploymentFromSpec(entry.setup.nodeGroups[0], m)
+			md, err := buildNodeGroupImplFromSpec(entry.setup.nodeGroups[0], m)
 			g.Expect(err).To(BeNil())
 
 			returnedInstances, err := md.Nodes()
@@ -645,7 +645,7 @@ func TestGetOptions(t *testing.T) {
 				nodeGroups: []string{nodeGroup1},
 			},
 			expect{
-				err: fmt.Errorf("unable to fetch MachineDeployment object machinedeployment-1, Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
+				err: fmt.Errorf("unable to fetch NodeGroupImpl object machinedeployment-1, Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
 			},
 		},
 		{
@@ -733,7 +733,7 @@ func TestGetOptions(t *testing.T) {
 			defer trackers.Stop()
 			waitForCacheSync(t, stop, hasSyncedCacheFns)
 
-			md, err := buildMachineDeploymentFromSpec(entry.setup.nodeGroups[0], m)
+			md, err := buildNodeGroupImplFromSpec(entry.setup.nodeGroups[0], m)
 			g.Expect(err).To(BeNil())
 
 			options, err := md.GetOptions(ngAutoScalingOpDefaults)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -401,24 +401,6 @@ func TestRefresh(t *testing.T) {
 				err: nil,
 			},
 		},
-		{
-			"priority reset of machine fails",
-			setup{
-				nodes:              newNodes(1, "fakeID"),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
-				controlMachineFakeResourceActions: &customfake.ResourceActions{
-					Machine: customfake.Actions{
-						Update: customfake.CreateFakeResponse(math.MaxInt32, mcUpdateErrorMsg, 0),
-					},
-				},
-				nodeGroups:    []string{nodeGroup2},
-				mcmDeployment: newMCMDeployment(1),
-			},
-			expect{
-				err: errors.Join(nil, errors.Join(fmt.Errorf("could not reset priority annotation on machine machine-1, Error: %v", mcUpdateErrorMsg))),
-			},
-		},
 	}
 	for _, entry := range table {
 		entry := entry

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -85,10 +86,11 @@ func TestDeleteNodes(t *testing.T) {
 		node *corev1.Node
 	}
 	type expect struct {
-		machines   []*v1alpha1.Machine
-		mdName     string
-		mdReplicas int32
-		err        error
+		prio1Machines                     []*v1alpha1.Machine
+		mdName                            string
+		mdReplicas                        int32
+		machinesMarkedByCAAnnotationValue string
+		err                               error
 	}
 	type data struct {
 		name   string
@@ -100,42 +102,44 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should scale down machine deployment to remove a node",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        nil,
+				prio1Machines:                     newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				mdName:                            "machinedeployment-1",
+				machinesMarkedByCAAnnotationValue: createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1)),
+				mdReplicas:                        1,
+				err:                               nil,
 			},
 		},
 		{
 			"should scale down machine deployment to remove a placeholder node",
 			setup{
 				nodes:              nil,
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
 			},
-			action{node: newNode("node-1", "requested://machine-1", true)},
+			action{node: newNode("node-1", "requested://machine-1")},
 			expect{
-				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				mdName:     "machinedeployment-1",
-				mdReplicas: 0,
-				err:        nil,
+				prio1Machines:                     newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				machinesMarkedByCAAnnotationValue: createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1)),
+				mdName:                            "machinedeployment-1",
+				mdReplicas:                        0,
+				err:                               nil,
 			},
 		},
 		{
 			"should not scale down a machine deployment when it is under rolling update",
 			setup{
-				nodes:       newNodes(2, "fakeID", []bool{true, false}),
-				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:       newNodes(2, "fakeID"),
+				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets: newMachineSets(2, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, &v1alpha1.MachineDeploymentStatus{
 					Conditions: []v1alpha1.MachineDeploymentCondition{
@@ -144,19 +148,19 @@ func TestDeleteNodes(t *testing.T) {
 				}, nil, nil),
 				nodeGroups: []string{nodeGroup1},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   nil,
-				mdName:     "machinedeployment-1",
-				mdReplicas: 2,
-				err:        fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-1",
+				mdReplicas:    2,
+				err:           fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
 			},
 		},
 		{
 			"should not scale down when machine deployment update call times out and should reset priority of the corresponding machine",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
@@ -166,9 +170,8 @@ func TestDeleteNodes(t *testing.T) {
 					},
 				},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
 				err:        errors.Join(nil, fmt.Errorf("unable to scale in machine deployment machinedeployment-1, Error: %w", errors.New(mdUpdateErrorMsg))),
@@ -177,8 +180,8 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should scale down when machine deployment update call fails but passes within the timeout period",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
@@ -188,26 +191,26 @@ func TestDeleteNodes(t *testing.T) {
 					},
 				},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        nil,
+				prio1Machines:                     newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				machinesMarkedByCAAnnotationValue: createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1)),
+				mdName:                            "machinedeployment-1",
+				mdReplicas:                        1,
+				err:                               nil,
 			},
 		},
 		{
 			"should not scale down a machine deployment when the corresponding machine is already in terminating state",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{true, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineTerminating}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{true}),
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
 				err:        nil,
@@ -216,15 +219,14 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should not scale down a machine deployment when the corresponding machine is already in failed state",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
 			},
-			action{node: newNodes(1, "fakeID", []bool{false})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   newMachines(2, "fakeID", &v1alpha1.MachineStatus{CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed}}, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
 				err:        nil,
@@ -233,25 +235,25 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should not scale down a machine deployment below the minimum",
 			setup{
-				nodes:              newNodes(1, "fakeID", []bool{true}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
+				nodes:              newNodes(1, "fakeID"),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   nil,
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        fmt.Errorf("min size reached, nodes will not be deleted"),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-1",
+				mdReplicas:    1,
+				err:           fmt.Errorf("min size reached, nodes will not be deleted"),
 			},
 		},
 		{
 			"no scale down of machine deployment if priority of the targeted machine cannot be updated to 1",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-1"),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup1},
@@ -261,29 +263,29 @@ func TestDeleteNodes(t *testing.T) {
 					},
 				},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   nil,
-				mdName:     "machinedeployment-1",
-				mdReplicas: 2,
-				err:        fmt.Errorf("could not prioritize machine machine-1 for deletion, aborting scale in of machine deployment, Error: %s", mcUpdateErrorMsg),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-1",
+				mdReplicas:    2,
+				err:           fmt.Errorf("could not prioritize machine machine-1 for deletion, aborting scale in of machine deployment, Error: %s", mcUpdateErrorMsg),
 			},
 		},
 		{
 			"should not scale down machine deployment if the node belongs to another machine deployment",
 			setup{
-				nodes:              newNodes(2, "fakeID", []bool{true, false}),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-2", "machineset-1", []string{"3", "3"}, []bool{false, false}),
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-2", "machineset-1", []string{"3", "3"}),
 				machineSets:        newMachineSets(1, "machinedeployment-2"),
 				machineDeployments: newMachineDeployments(2, 2, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2, nodeGroup3},
 			},
-			action{node: newNodes(1, "fakeID", []bool{true})[0]},
+			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				machines:   nil,
-				mdName:     "machinedeployment-2",
-				mdReplicas: 2,
-				err:        fmt.Errorf("node-1 belongs to a different machinedeployment than machinedeployment-1"),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-2",
+				mdReplicas:    2,
+				err:           fmt.Errorf("node-1 belongs to a different machinedeployment than machinedeployment-1"),
 			},
 		},
 	}
@@ -296,7 +298,7 @@ func TestDeleteNodes(t *testing.T) {
 			stop := make(chan struct{})
 			defer close(stop)
 			controlMachineObjects, targetCoreObjects, _ := setupEnv(&entry.setup)
-			m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, nil, controlMachineObjects, targetCoreObjects, nil)
+			m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, entry.setup.nodeGroups, controlMachineObjects, targetCoreObjects, nil)
 			defer trackers.Stop()
 			waitForCacheSync(t, stop, hasSyncedCacheFns)
 
@@ -321,6 +323,7 @@ func TestDeleteNodes(t *testing.T) {
 			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
+			g.Expect(machineDeployment.Annotations[machinesMarkedByCAForDeletion]).To(Equal(entry.expect.machinesMarkedByCAAnnotationValue))
 
 			machines, err := m.machineClient.Machines(m.namespace).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: metav1.FormatLabelSelector(&metav1.LabelSelector{
@@ -329,26 +332,52 @@ func TestDeleteNodes(t *testing.T) {
 			})
 
 			for _, machine := range machines.Items {
-				flag := false
-				for _, entryMachineItem := range entry.expect.machines {
-					if entryMachineItem.Name == machine.Name {
-						g.Expect(machine.Annotations[machinePriorityAnnotation]).To(Equal(entryMachineItem.Annotations[machinePriorityAnnotation]))
-						flag = true
-						break
-					}
-				}
-				if !flag {
-					g.Expect(machine.Annotations[machinePriorityAnnotation]).To(Equal("3"))
+				if slices.ContainsFunc(entry.expect.prio1Machines, func(m *v1alpha1.Machine) bool {
+					return machine.Name == m.Name
+				}) {
+					g.Expect(machine.Annotations[machinePriorityAnnotation]).To(Equal(priorityValueForDeletionCandidateMachines))
+				} else {
+					g.Expect(machine.Annotations[machinePriorityAnnotation]).To(Equal(defaultPriorityValue))
 				}
 			}
 		})
 	}
 }
 
+func TestIdempotencyOfDeleteNodes(t *testing.T) {
+	setupObj := setup{
+		nodes:              newNodes(3, "fakeID"),
+		machines:           newMachines(3, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3", "3"}),
+		machineSets:        newMachineSets(1, "machinedeployment-1"),
+		machineDeployments: newMachineDeployments(1, 3, nil, nil, nil),
+		nodeGroups:         []string{nodeGroup1},
+	}
+	g := NewWithT(t)
+	stop := make(chan struct{})
+	defer close(stop)
+	controlMachineObjects, targetCoreObjects, _ := setupEnv(&setupObj)
+	m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, setupObj.nodeGroups, controlMachineObjects, targetCoreObjects, nil)
+	defer trackers.Stop()
+	waitForCacheSync(t, stop, hasSyncedCacheFns)
+	md, err := buildMachineDeploymentFromSpec(setupObj.nodeGroups[0], m)
+	g.Expect(err).To(BeNil())
+
+	err = md.DeleteNodes(newNodes(1, "fakeID"))
+	g.Expect(err).To(BeNil())
+	err = md.DeleteNodes(newNodes(1, "fakeID"))
+	g.Expect(err).To(BeNil())
+
+	machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), setupObj.machineDeployments[0].Name, metav1.GetOptions{})
+	g.Expect(err).ToNot(HaveOccurred())
+	g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", 2))
+	g.Expect(machineDeployment.Annotations[machinesMarkedByCAForDeletion]).To(Equal(createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1))))
+}
+
 func TestRefresh(t *testing.T) {
 	type expect struct {
-		machines []*v1alpha1.Machine
-		err      error
+		prio3Machines                                []string
+		machinesMarkedByCAForDeletionAnnotationValue string
+		err                                          error
 	}
 	type data struct {
 		name   string
@@ -359,8 +388,8 @@ func TestRefresh(t *testing.T) {
 		{
 			"should return an error if MCM has zero available replicas",
 			setup{
-				nodes:              newNodes(1, "fakeID", []bool{false}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
+				nodes:              newNodes(1, "fakeID"),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
 				mcmDeployment:      newMCMDeployment(0),
@@ -372,8 +401,8 @@ func TestRefresh(t *testing.T) {
 		{
 			"should return an error if MCM deployment is not found",
 			setup{
-				nodes:              newNodes(1, "fakeID", []bool{false}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
+				nodes:              newNodes(1, "fakeID"),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
 			},
@@ -382,88 +411,38 @@ func TestRefresh(t *testing.T) {
 			},
 		},
 		{
-			"should reset priority of a machine to 3 if machine deployment is not scaled in",
+			"should reset priority of a machine if it is not present in machines-marked-by-ca-for-deletion annotation on machine deployment",
 			setup{
-				nodes:              newNodes(1, "fakeID", []bool{false}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
+				nodes:              newNodes(1, "fakeID"),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				nodeGroups:         []string{nodeGroup2},
 				mcmDeployment:      newMCMDeployment(1),
 			},
 			expect{
-				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
-				err:      nil,
+				prio3Machines: generateNames("machine", 1),
+				err:           nil,
 			},
 		},
 		{
-			"should reset priority of a machine to 3 if machine deployment is not scaled in even if ToBeDeletedTaint is present on the corresponding node",
+			"should update the machines-marked-by-ca-for-deletion annotation and remove non-existing machines",
 			setup{
-				nodes:              newNodes(1, "fakeID", []bool{true}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
+				nodes:              newNodes(1, "fakeID"),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				machineDeployments: newMachineDeployments(1, 0, nil, map[string]string{machinesMarkedByCAForDeletion: "machine-1,machine-2"}, nil),
 				nodeGroups:         []string{nodeGroup2},
 				mcmDeployment:      newMCMDeployment(1),
 			},
 			expect{
-				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
-				err:      nil,
-			},
-		},
-		{
-			"should NOT skip paused machine deployment",
-			setup{
-				nodes:    newNodes(1, "fakeID", []bool{false}),
-				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				machineDeployments: newMachineDeployments(1, 1, &v1alpha1.MachineDeploymentStatus{
-					Conditions: []v1alpha1.MachineDeploymentCondition{
-						{Type: v1alpha1.MachineDeploymentProgressing, Status: v1alpha1.ConditionUnknown, Reason: machineDeploymentPausedReason},
-					},
-				}, nil, nil),
-				nodeGroups:    []string{nodeGroup2},
-				mcmDeployment: newMCMDeployment(1),
-			},
-			expect{
-				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}, []bool{false}),
-				err:      nil,
-			},
-		},
-		{
-			"should ignore terminating/failed machines in checking if number of annotated machines is more than desired",
-			setup{
-				nodes: newNodes(1, "fakeID", []bool{true}),
-				machines: newMachines(1, "fakeID", &v1alpha1.MachineStatus{
-					CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed},
-				}, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
-				nodeGroups:         []string{nodeGroup2},
-				mcmDeployment:      newMCMDeployment(1),
-			},
-			expect{
-				machines: newMachines(1, "fakeID", &v1alpha1.MachineStatus{
-					CurrentStatus: v1alpha1.CurrentStatus{Phase: v1alpha1.MachineFailed},
-				}, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
+				machinesMarkedByCAForDeletionAnnotationValue: createMachinesMarkedForDeletionAnnotationValue(generateNames("machine", 1)),
 				err: nil,
-			},
-		},
-		{
-			"should not reset priority of a machine to 3 if machine deployment is scaled in",
-			setup{
-				nodes:              newNodes(1, "fakeID", []bool{true}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				machineDeployments: newMachineDeployments(1, 0, nil, nil, nil),
-				nodeGroups:         []string{nodeGroup2},
-				mcmDeployment:      newMCMDeployment(1),
-			},
-			expect{
-				machines: newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
-				err:      nil,
 			},
 		},
 		{
 			"priority reset of machine fails",
 			setup{
-				nodes:              newNodes(1, "fakeID", []bool{false}),
-				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}, []bool{false}),
+				nodes:              newNodes(1, "fakeID"),
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
 				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
 				controlMachineFakeResourceActions: &customfake.ResourceActions{
 					Machine: customfake.Actions{
@@ -474,8 +453,7 @@ func TestRefresh(t *testing.T) {
 				mcmDeployment: newMCMDeployment(1),
 			},
 			expect{
-				machines: []*v1alpha1.Machine{newMachine("machine-1", "fakeID-1", nil, "machinedeployment-1", "machineset-1", "1", false, true)},
-				err:      errors.Join(nil, errors.Join(fmt.Errorf("could not reset priority annotation on machine machine-1, Error: %v", mcUpdateErrorMsg))),
+				err: errors.Join(nil, errors.Join(fmt.Errorf("could not reset priority annotation on machine machine-1, Error: %v", mcUpdateErrorMsg))),
 			},
 		},
 	}
@@ -505,10 +483,14 @@ func TestRefresh(t *testing.T) {
 			} else {
 				g.Expect(err).To(BeNil())
 			}
-			for _, mc := range entry.expect.machines {
-				machine, err := m.machineClient.Machines(m.namespace).Get(context.TODO(), mc.Name, metav1.GetOptions{})
-				g.Expect(err).To(BeNil())
-				g.Expect(mc.Annotations[machinePriorityAnnotation]).To(Equal(machine.Annotations[machinePriorityAnnotation]))
+			machines, err := m.machineClient.Machines(m.namespace).List(context.TODO(), metav1.ListOptions{})
+			g.Expect(err).To(BeNil())
+			for _, mc := range machines.Items {
+				if slices.Contains(entry.expect.prio3Machines, mc.Name) {
+					g.Expect(mc.Annotations[machinePriorityAnnotation]).To(Equal(defaultPriorityValue))
+				} else {
+					g.Expect(mc.Annotations[machinePriorityAnnotation]).To(Equal(priorityValueForDeletionCandidateMachines))
+				}
 			}
 		})
 	}
@@ -554,14 +536,14 @@ func TestNodes(t *testing.T) {
 		{
 			"Correct instances should be returned for machine objects under the machinedeployment",
 			setup{
-				nodes: []*corev1.Node{newNode("node-1", "fakeID-1", false)},
+				nodes: []*corev1.Node{newNode("node-1", "fakeID-1")},
 				machines: func() []*v1alpha1.Machine {
 					allMachines := make([]*v1alpha1.Machine, 0, 5)
-					allMachines = append(allMachines, newMachine("machine-with-registered-node", "fakeID-1", nil, "machinedeployment-1", "", "", false, true))
-					allMachines = append(allMachines, newMachine("machine-with-vm-but-no-node", "fakeID-2", nil, "machinedeployment-1", "", "", false, false))
-					allMachines = append(allMachines, newMachine("machine-with-vm-creating", "", nil, "machinedeployment-1", "", "", false, false))
-					allMachines = append(allMachines, newMachine("machine-with-vm-create-error-out-of-quota", "", &v1alpha1.MachineStatus{LastOperation: v1alpha1.LastOperation{Type: v1alpha1.MachineOperationCreate, State: v1alpha1.MachineStateFailed, ErrorCode: machinecodes.ResourceExhausted.String(), Description: outOfQuotaMachineStatusErrorDescription}}, "machinedeployment-1", "", "", false, false))
-					allMachines = append(allMachines, newMachine("machine-with-vm-create-error-invalid-credentials", "", &v1alpha1.MachineStatus{LastOperation: v1alpha1.LastOperation{Type: v1alpha1.MachineOperationCreate, State: v1alpha1.MachineStateFailed, ErrorCode: machinecodes.Internal.String(), Description: invalidCredentialsMachineStatusErrorDescription}}, "machinedeployment-1", "", "", false, false))
+					allMachines = append(allMachines, newMachine("machine-with-registered-node", "fakeID-1", nil, "machinedeployment-1", "", "", true))
+					allMachines = append(allMachines, newMachine("machine-with-vm-but-no-node", "fakeID-2", nil, "machinedeployment-1", "", "", false))
+					allMachines = append(allMachines, newMachine("machine-with-vm-creating", "", nil, "machinedeployment-1", "", "", false))
+					allMachines = append(allMachines, newMachine("machine-with-vm-create-error-out-of-quota", "", &v1alpha1.MachineStatus{LastOperation: v1alpha1.LastOperation{Type: v1alpha1.MachineOperationCreate, State: v1alpha1.MachineStateFailed, ErrorCode: machinecodes.ResourceExhausted.String(), Description: outOfQuotaMachineStatusErrorDescription}}, "machinedeployment-1", "", "", false))
+					allMachines = append(allMachines, newMachine("machine-with-vm-create-error-invalid-credentials", "", &v1alpha1.MachineStatus{LastOperation: v1alpha1.LastOperation{Type: v1alpha1.MachineOperationCreate, State: v1alpha1.MachineStateFailed, ErrorCode: machinecodes.Internal.String(), Description: invalidCredentialsMachineStatusErrorDescription}}, "machinedeployment-1", "", "", false))
 					return allMachines
 				}(),
 				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -153,7 +153,7 @@ func TestDeleteNodes(t *testing.T) {
 				prio1Machines: nil,
 				mdName:        "machinedeployment-1",
 				mdReplicas:    2,
-				err:           fmt.Errorf("NodeGroupImpl machinedeployment-1 is under rolling update , cannot reduce replica count"),
+				err:           fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
 			},
 		},
 		{
@@ -645,7 +645,7 @@ func TestGetOptions(t *testing.T) {
 				nodeGroups: []string{nodeGroup1},
 			},
 			expect{
-				err: fmt.Errorf("unable to fetch NodeGroupImpl object machinedeployment-1, Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
+				err: fmt.Errorf("unable to fetch MachineDeployment object machinedeployment-1, Error: machinedeployment.machine.sapcloud.io \"machinedeployment-1\" not found"),
 			},
 		},
 		{

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -287,7 +287,7 @@ func TestDeleteNodes(t *testing.T) {
 				trackers.ControlMachine.SetFailAtFakeResourceActions(entry.setup.controlMachineFakeResourceActions)
 			}
 
-			md, err := buildNodeGroupImplFromSpec(entry.setup.nodeGroups[0], m)
+			md, err := buildNodeGroupFromSpec(entry.setup.nodeGroups[0], m)
 			g.Expect(err).To(BeNil())
 
 			err = md.DeleteNodes([]*corev1.Node{entry.action.node})
@@ -322,7 +322,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, setupObj.nodeGroups, controlMachineObjects, targetCoreObjects, nil)
 	defer trackers.Stop()
 	waitForCacheSync(t, stop, hasSyncedCacheFns)
-	md, err := buildNodeGroupImplFromSpec(setupObj.nodeGroups[0], m)
+	md, err := buildNodeGroupFromSpec(setupObj.nodeGroups[0], m)
 	g.Expect(err).To(BeNil())
 
 	err = md.DeleteNodes(newNodes(1, "fakeID"))
@@ -517,7 +517,7 @@ func TestNodes(t *testing.T) {
 				trackers.ControlMachine.SetFailAtFakeResourceActions(entry.setup.controlMachineFakeResourceActions)
 			}
 
-			md, err := buildNodeGroupImplFromSpec(entry.setup.nodeGroups[0], m)
+			md, err := buildNodeGroupFromSpec(entry.setup.nodeGroups[0], m)
 			g.Expect(err).To(BeNil())
 
 			returnedInstances, err := md.Nodes()
@@ -669,7 +669,7 @@ func TestGetOptions(t *testing.T) {
 			defer trackers.Stop()
 			waitForCacheSync(t, stop, hasSyncedCacheFns)
 
-			md, err := buildNodeGroupImplFromSpec(entry.setup.nodeGroups[0], m)
+			md, err := buildNodeGroupFromSpec(entry.setup.nodeGroups[0], m)
 			g.Expect(err).To(BeNil())
 
 			options, err := md.GetOptions(ngAutoScalingOpDefaults)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -171,7 +171,6 @@ func TestDeleteNodes(t *testing.T) {
 				},
 			},
 			action{node: newNodes(1, "fakeID")[0]},
-			//return fmt.Errorf("for NodeGroup %q, cannot scale down due to: %v", ngImpl.Name, toDeleteMachineNames, err)
 			expect{
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -100,8 +100,7 @@ const (
 	machineDeploymentPausedReason = "DeploymentPaused"
 	// machineDeploymentNameLabel key for Machine Deployment name in machine labels
 	machineDeploymentNameLabel = "name"
-	// machinesMarkedByCAForDeletionAnnotation is the annotation set by CA on machine deployment. Its value denotes the machines that
-	// CA marked for deletion by updating the priority annotation to 1 and scaling down the machine deployment.
+	// machinesMarkedByCAForDeletionAnnotation is the annotation set by CA on the MachineDeployment and represents machines that must be drained and deleted.
 	machinesMarkedByCAForDeletionAnnotation = "cluster-autoscaler.kubernetes.io/machines-marked-by-ca-for-deletion"
 	// poolNameLabel is the name of the label for gardener worker pool
 	poolNameLabel = "worker.gardener.cloud/pool"

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -507,7 +507,7 @@ func (m *McmManager) scaleDownMachineDeployment(ctx context.Context, mdName stri
 		return true, err
 	}
 
-	data := computeScaledownData(md, toBeDeletedMachineNames)
+	data := computeScaleDownData(md, toBeDeletedMachineNames)
 	if data.RevisedScaledownAmount == 0 {
 		klog.V(3).Infof("Skipping scaledown since MachineDeployment %q has already marked %v for deletion by MCM, skipping the scale-down", md.Name, toBeDeletedMachineNames)
 		return false, nil
@@ -1076,8 +1076,9 @@ func filterExtendedResources(allResources v1.ResourceList) (extendedResources v1
 	return
 }
 
-// computeScaledownData computes fresh scaleDownData for the given MachineDeployment given the machineNamesForDeletion
-func computeScaledownData(md *v1alpha1.MachineDeployment, machineNamesForDeletion []string) (data scaleDownData) {
+// computeScaleDownData computes fresh scaleDownData for the given input MachineDeployment and the machineNamesForDeletion.
+// The output scaleDownData encapsulates the scale-down amount and an updated, non-nil MachineDeployment.
+func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletion []string) (data scaleDownData) {
 	forDeletionSet := sets.New(machineNamesForDeletion...)
 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -1064,9 +1064,9 @@ func buildNodeGroupImpl(mcmManager *McmManager, minSize int, maxSize int, namesp
 }
 
 // isMachineFailedOrTerminating returns true if machine is already being terminated or considered for termination by autoscaler.
+// TODO: Move to MCM machineutils.IsMachineFailedOrTerminating after MCM release.
 func isMachineFailedOrTerminating(machine *v1alpha1.Machine) bool {
 	if !machine.GetDeletionTimestamp().IsZero() || machine.Status.CurrentStatus.Phase == v1alpha1.MachineFailed {
-		klog.Infof("Machine %q is already being terminated or in a failed phase, and hence skipping the deletion", machine.Name)
 		return true
 	}
 	return false

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -254,6 +254,7 @@ func createMCMManagerInternal(discoveryOpts cloudprovider.NodeGroupDiscoveryOpti
 		m := &McmManager{
 			namespace:               namespace,
 			interrupt:               make(chan struct{}),
+			machineDeployments:      make(map[types.NamespacedName]*MachineDeployment),
 			deploymentLister:        deploymentLister,
 			machineClient:           controlMachineClient,
 			machineClassLister:      machineClassLister,

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -899,8 +899,8 @@ func (m *McmManager) GetMachineDeploymentNodeTemplate(nodeGroupName string) (*no
 func (m *McmManager) GetMachineDeploymentObject(mdName string) (*v1alpha1.MachineDeployment, error) {
 	md, err := m.machineDeploymentLister.MachineDeployments(m.namespace).Get(mdName)
 	if err != nil {
-		klog.Errorf("unable to fetch MachineDeployments object %s, Error: %v", mdName, err)
-		return nil, fmt.Errorf("unable to fetch MachineDeployments object %s, Error: %v", mdName, err)
+		klog.Errorf("unable to fetch MachineDeployment object %s, Error: %v", mdName, err)
+		return nil, fmt.Errorf("unable to fetch MachineDeployment object %s, Error: %v", mdName, err)
 	}
 	return md, nil
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -251,10 +251,10 @@ func TestComputeScaledownData(t *testing.T) {
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
 
 		md = data.RevisedMachineDeployment
-		// repeating computeScaleDownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
+		// repeating computeScaleDownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedMachineNames, and nil RevisedMachineDeployment
 		data = computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, 0, data.RevisedScaledownAmount)
-		assert.Empty(t, data.RevisedToBeDeletedNames)
+		assert.Empty(t, data.RevisedToBeDeletedMachineNames)
 		assert.Nil(t, data.RevisedMachineDeployment)
 
 	})
@@ -272,10 +272,10 @@ func TestComputeScaledownData(t *testing.T) {
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
 
 		md = data.RevisedMachineDeployment
-		// repeating computeScaleDownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
+		// repeating computeScaleDownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedMachineNames, and nil RevisedMachineDeployment
 		data = computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, 0, data.RevisedScaledownAmount)
-		assert.Empty(t, data.RevisedToBeDeletedNames)
+		assert.Empty(t, data.RevisedToBeDeletedMachineNames)
 		assert.Nil(t, data.RevisedMachineDeployment)
 
 	})
@@ -298,7 +298,7 @@ func TestComputeScaledownData(t *testing.T) {
 		assert.NotNil(t, data.RevisedMachineDeployment)
 		uniqueMachinesNamesForDeletion := newMachineNamesForDeletion.Difference(machineNamesForDeletion)
 		assert.Equal(t, uniqueMachinesNamesForDeletion.Len(), data.RevisedScaledownAmount)
-		assert.Equal(t, uniqueMachinesNamesForDeletion, data.RevisedToBeDeletedNames)
+		assert.Equal(t, uniqueMachinesNamesForDeletion, data.RevisedToBeDeletedMachineNames)
 		expectedReplicas = int32(initialReplicas - machineNamesForDeletion.Union(newMachineNamesForDeletion).Len())
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -231,7 +231,7 @@ func TestComputeScaledownData(t *testing.T) {
 		md.Annotations = map[string]string{}
 
 		machineNamesForDeletion := []string{"n1"}
-		data := computeScaledownData(md, machineNamesForDeletion)
+		data := computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		assert.Equal(t, int32(2-len(machineNamesForDeletion)), data.RevisedMachineDeployment.Spec.Replicas)
@@ -243,7 +243,7 @@ func TestComputeScaledownData(t *testing.T) {
 		md.Annotations = map[string]string{}
 
 		machineNamesForDeletion := []string{"n1"}
-		data := computeScaledownData(md, machineNamesForDeletion)
+		data := computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 
@@ -251,8 +251,8 @@ func TestComputeScaledownData(t *testing.T) {
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
 
 		md = data.RevisedMachineDeployment
-		// repeating computeScaledownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
-		data = computeScaledownData(md, machineNamesForDeletion)
+		// repeating computeScaleDownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
+		data = computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, 0, data.RevisedScaledownAmount)
 		assert.Empty(t, data.RevisedToBeDeletedNames)
 		assert.Nil(t, data.RevisedMachineDeployment)
@@ -265,15 +265,15 @@ func TestComputeScaledownData(t *testing.T) {
 		md.Annotations = map[string]string{}
 
 		machineNamesForDeletion := []string{"n1", "n2"}
-		data := computeScaledownData(md, machineNamesForDeletion)
+		data := computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
 
 		md = data.RevisedMachineDeployment
-		// repeating computeScaledownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
-		data = computeScaledownData(md, machineNamesForDeletion)
+		// repeating computeScaleDownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
+		data = computeScaleDownData(md, machineNamesForDeletion)
 		assert.Equal(t, 0, data.RevisedScaledownAmount)
 		assert.Empty(t, data.RevisedToBeDeletedNames)
 		assert.Nil(t, data.RevisedMachineDeployment)
@@ -286,7 +286,7 @@ func TestComputeScaledownData(t *testing.T) {
 		md.Annotations = map[string]string{}
 
 		machineNamesForDeletion := sets.New("n1", "n2")
-		data := computeScaledownData(md, machineNamesForDeletion.UnsortedList())
+		data := computeScaleDownData(md, machineNamesForDeletion.UnsortedList())
 		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion.UnsortedList()), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
@@ -294,7 +294,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		newMachineNamesForDeletion := sets.New("n2", "n3", "n4")
 		md = data.RevisedMachineDeployment
-		data = computeScaledownData(md, newMachineNamesForDeletion.UnsortedList())
+		data = computeScaleDownData(md, newMachineNamesForDeletion.UnsortedList())
 		assert.NotNil(t, data.RevisedMachineDeployment)
 		uniqueMachinesNamesForDeletion := newMachineNamesForDeletion.Difference(machineNamesForDeletion)
 		assert.Equal(t, uniqueMachinesNamesForDeletion.Len(), data.RevisedScaledownAmount)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -19,6 +19,8 @@ package mcm
 import (
 	"errors"
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/utils/ptr"
 	"maps"
@@ -220,6 +222,87 @@ func TestFilterExtendedResources(t *testing.T) {
 	extendedResources := filterExtendedResources(allResources)
 	t.Logf("TestFilterExtendedResources obtained: %+v", extendedResources)
 	assert.Equal(t, customResources, extendedResources)
+}
+
+func TestComputeScaledownData(t *testing.T) {
+	t.Run("simple", func(t *testing.T) {
+		initialReplicas := int32(2)
+		md := newMachineDeployments(1, initialReplicas, nil, nil, nil)[0]
+		md.Annotations = map[string]string{}
+
+		machineNamesForDeletion := []string{"n1"}
+		data := computeScaledownData(md, machineNamesForDeletion)
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
+		assert.Equal(t, int32(2-len(machineNamesForDeletion)), data.RevisedMachineDeployment.Spec.Replicas)
+	})
+
+	t.Run("single-duplicate", func(t *testing.T) {
+		initialReplicas := 2
+		md := newMachineDeployments(1, int32(initialReplicas), nil, nil, nil)[0]
+		md.Annotations = map[string]string{}
+
+		machineNamesForDeletion := []string{"n1"}
+		data := computeScaledownData(md, machineNamesForDeletion)
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
+
+		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
+		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
+
+		md = data.RevisedMachineDeployment
+		// repeating computeScaledownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
+		data = computeScaledownData(md, machineNamesForDeletion)
+		assert.Equal(t, 0, data.RevisedScaledownAmount)
+		assert.Empty(t, data.RevisedToBeDeletedNames)
+		assert.Nil(t, data.RevisedMachineDeployment)
+
+	})
+
+	t.Run("multi-duplicates", func(t *testing.T) {
+		initialReplicas := 3
+		md := newMachineDeployments(1, int32(initialReplicas), nil, nil, nil)[0]
+		md.Annotations = map[string]string{}
+
+		machineNamesForDeletion := []string{"n1", "n2"}
+		data := computeScaledownData(md, machineNamesForDeletion)
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
+		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
+		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
+
+		md = data.RevisedMachineDeployment
+		// repeating computeScaledownData for same machineNamesForDeletion should have 0 RevisedScaledownAmount, empty RevisedToBeDeletedNames, and nil RevisedMachineDeployment
+		data = computeScaledownData(md, machineNamesForDeletion)
+		assert.Equal(t, 0, data.RevisedScaledownAmount)
+		assert.Empty(t, data.RevisedToBeDeletedNames)
+		assert.Nil(t, data.RevisedMachineDeployment)
+
+	})
+
+	t.Run("overlapping", func(t *testing.T) {
+		initialReplicas := 5
+		md := newMachineDeployments(1, int32(initialReplicas), nil, nil, nil)[0]
+		md.Annotations = map[string]string{}
+
+		machineNamesForDeletion := sets.New("n1", "n2")
+		data := computeScaledownData(md, machineNamesForDeletion.UnsortedList())
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion.UnsortedList()), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
+		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
+		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
+
+		newMachineNamesForDeletion := sets.New("n2", "n3", "n4")
+		md = data.RevisedMachineDeployment
+		data = computeScaledownData(md, newMachineNamesForDeletion.UnsortedList())
+		assert.NotNil(t, data.RevisedMachineDeployment)
+		uniqueMachinesNamesForDeletion := newMachineNamesForDeletion.Difference(machineNamesForDeletion)
+		assert.Equal(t, uniqueMachinesNamesForDeletion.Len(), data.RevisedScaledownAmount)
+		assert.Equal(t, uniqueMachinesNamesForDeletion, data.RevisedToBeDeletedNames)
+		expectedReplicas = int32(initialReplicas - machineNamesForDeletion.Union(newMachineNamesForDeletion).Len())
+		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
+
+	})
 }
 
 func createSampleInstanceType(instanceTypeName string, customResourceName apiv1.ResourceName, customResourceQuantity resource.Quantity) *instanceType {

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -141,7 +141,6 @@ func newMachines(
 					{Name: msName},
 				},
 				Labels:            map[string]string{machineDeploymentNameLabel: mdName},
-				Annotations:       map[string]string{machinePriorityAnnotation: priorityAnnotationValues[i]},
 				CreationTimestamp: metav1.Now(),
 			},
 		}

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -290,6 +290,7 @@ func createMcmManager(
 		machineLister:           machines.Lister(),
 		machineClassLister:      machineClasses.Lister(),
 		nodeLister:              nodes.Lister(),
+		nodeInterface:           fakeTargetCoreClient.CoreV1().Nodes(),
 		maxRetryTimeout:         5 * time.Second,
 		retryInterval:           1 * time.Second,
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -46,7 +46,7 @@ func newMachineDeployments(
 		machineDeployment := &v1alpha1.MachineDeployment{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.sapcloud.io",
-				Kind:       "NodeGroupImpl",
+				Kind:       "MachineDeployment",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("machinedeployment-%d", i+1),
@@ -282,7 +282,7 @@ func createMcmManager(
 		discoveryOpts: cloudprovider.NodeGroupDiscoveryOptions{
 			NodeGroupSpecs: nodeGroups,
 		},
-		nodeGroups:              make(map[types.NamespacedName]*NodeGroupImpl),
+		nodeGroups:              make(map[types.NamespacedName]*nodeGroup),
 		deploymentLister:        appsControlSharedInformers.Deployments().Lister(),
 		machineClient:           fakeTypedMachineClient,
 		machineDeploymentLister: machineDeployments.Lister(),

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -7,6 +7,7 @@ package mcm
 import (
 	"fmt"
 	appsv1 "k8s.io/api/apps/v1"
+	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"testing"
 	"time"
@@ -24,7 +25,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	customfake "k8s.io/autoscaler/cluster-autoscaler/cloudprovider/mcm/fakeclient"
-	deletetaint "k8s.io/autoscaler/cluster-autoscaler/utils/taints"
 	appsv1informers "k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers"
 )
@@ -42,7 +42,7 @@ func newMachineDeployments(
 	labels map[string]string,
 ) []*v1alpha1.MachineDeployment {
 	machineDeployments := make([]*v1alpha1.MachineDeployment, machineDeploymentCount)
-	for i := range machineDeployments {
+	for i := 0; i < machineDeploymentCount; i++ {
 		machineDeployment := &v1alpha1.MachineDeployment{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.sapcloud.io",
@@ -74,7 +74,7 @@ func newMachineSets(
 ) []*v1alpha1.MachineSet {
 
 	machineSets := make([]*v1alpha1.MachineSet, machineSetCount)
-	for i := range machineSets {
+	for i := 0; i < machineSetCount; i++ {
 		ms := &v1alpha1.MachineSet{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.sapcloud.io",
@@ -97,10 +97,9 @@ func newMachine(
 	statusTemplate *v1alpha1.MachineStatus,
 	mdName, msName string,
 	priorityAnnotationValue string,
-	setDeletionTimeStamp,
 	setNodeLabel bool,
 ) *v1alpha1.Machine {
-	m := newMachines(1, providerId, statusTemplate, mdName, msName, []string{priorityAnnotationValue}, []bool{setDeletionTimeStamp})[0]
+	m := newMachines(1, providerId, statusTemplate, mdName, msName, []string{priorityAnnotationValue})[0]
 	m.Name = name
 	m.Spec.ProviderID = providerId
 	if !setNodeLabel {
@@ -109,26 +108,34 @@ func newMachine(
 	return m
 }
 
+func generateNames(prefix string, count int) []string {
+	names := make([]string, count)
+	for i := 0; i < count; i++ {
+		names[i] = fmt.Sprintf("%s-%d", prefix, i+1)
+	}
+	return names
+}
+
 func newMachines(
 	machineCount int,
 	providerIdGenerateName string,
 	statusTemplate *v1alpha1.MachineStatus,
 	mdName, msName string,
 	priorityAnnotationValues []string,
-	setDeletionTimeStamp []bool,
 ) []*v1alpha1.Machine {
 	machines := make([]*v1alpha1.Machine, machineCount)
-
+	machineNames := generateNames("machine", machineCount)
+	nodeNames := generateNames("node", machineCount)
 	currentTime := metav1.Now()
 
-	for i := range machines {
+	for i := 0; i < machineCount; i++ {
 		m := &v1alpha1.Machine{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.sapcloud.io",
 				Kind:       "Machine",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("machine-%d", i+1),
+				Name:      machineNames[i],
 				Namespace: testNamespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{Name: msName},
@@ -143,12 +150,12 @@ func newMachines(
 			m.Spec = v1alpha1.MachineSpec{ProviderID: fmt.Sprintf("%s/i%d", providerIdGenerateName, i+1)}
 		}
 
-		m.Labels["node"] = fmt.Sprintf("node-%d", i+1)
-		if setDeletionTimeStamp[i] {
-			m.ObjectMeta.DeletionTimestamp = &currentTime
-		}
+		m.Labels["node"] = nodeNames[i]
 		if statusTemplate != nil {
 			m.Status = *newMachineStatus(statusTemplate)
+			if m.Status.CurrentStatus.Phase == v1alpha1.MachineTerminating {
+				m.DeletionTimestamp = &currentTime
+			}
 		}
 		machines[i] = m
 	}
@@ -158,9 +165,8 @@ func newMachines(
 func newNode(
 	nodeName,
 	providerId string,
-	addToBeDeletedTaint bool,
 ) *corev1.Node {
-	node := newNodes(1, providerId, []bool{addToBeDeletedTaint})[0]
+	node := newNodes(1, providerId)[0]
 	clone := node.DeepCopy()
 	clone.Name = nodeName
 	clone.Spec.ProviderID = providerId
@@ -170,30 +176,20 @@ func newNode(
 func newNodes(
 	nodeCount int,
 	providerIdGenerateName string,
-	addToBeDeletedTaint []bool,
 ) []*corev1.Node {
-
 	nodes := make([]*corev1.Node, nodeCount)
-	for i := range nodes {
-		var taints []corev1.Taint
-		if addToBeDeletedTaint[i] {
-			taints = append(taints, corev1.Taint{
-				Key:    deletetaint.ToBeDeletedTaint,
-				Value:  testTaintValue,
-				Effect: corev1.TaintEffectNoSchedule,
-			})
-		}
+	nodeNames := generateNames("node", nodeCount)
+	for i := 0; i < nodeCount; i++ {
 		node := &corev1.Node{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "appsv1",
 				Kind:       "Node",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("node-%d", i+1),
+				Name: nodeNames[i],
 			},
 			Spec: corev1.NodeSpec{
 				ProviderID: fmt.Sprintf("%s/i%d", providerIdGenerateName, i+1),
-				Taints:     taints,
 			},
 		}
 
@@ -287,6 +283,7 @@ func createMcmManager(
 		discoveryOpts: cloudprovider.NodeGroupDiscoveryOptions{
 			NodeGroupSpecs: nodeGroups,
 		},
+		machineDeployments:      make(map[types.NamespacedName]*MachineDeployment),
 		deploymentLister:        appsControlSharedInformers.Deployments().Lister(),
 		machineClient:           fakeTypedMachineClient,
 		machineDeploymentLister: machineDeployments.Lister(),
@@ -297,7 +294,7 @@ func createMcmManager(
 		maxRetryTimeout:         5 * time.Second,
 		retryInterval:           1 * time.Second,
 	}
-
+	g.Expect(mcmManager.generateMachineDeploymentMap()).To(gomega.Succeed())
 	hasSyncedCachesFns := []cache.InformerSynced{
 		nodes.Informer().HasSynced,
 		machines.Informer().HasSynced,

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -46,7 +46,7 @@ func newMachineDeployments(
 		machineDeployment := &v1alpha1.MachineDeployment{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "machine.sapcloud.io",
-				Kind:       "MachineDeployment",
+				Kind:       "NodeGroupImpl",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("machinedeployment-%d", i+1),
@@ -283,7 +283,7 @@ func createMcmManager(
 		discoveryOpts: cloudprovider.NodeGroupDiscoveryOptions{
 			NodeGroupSpecs: nodeGroups,
 		},
-		machineDeployments:      make(map[types.NamespacedName]*MachineDeployment),
+		nodeGroups:              make(map[types.NamespacedName]*NodeGroupImpl),
 		deploymentLister:        appsControlSharedInformers.Deployments().Lister(),
 		machineClient:           fakeTypedMachineClient,
 		machineDeploymentLister: machineDeployments.Lister(),

--- a/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils/utils.go
+++ b/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils/utils.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package machineutils contains the consts and global vaariables for machine operation
+package machineutils
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// GetVMStatus sets machine status to terminating and specifies next step as getting VMs
+	GetVMStatus = "Set machine status to termination. Now, getting VM Status"
+
+	// InstanceInitialization is a step that represents initialization of a VM instance (post-creation).
+	InstanceInitialization = "Initialize VM Instance"
+
+	// InitiateDrain specifies next step as initiate node drain
+	InitiateDrain = "Initiate node drain"
+
+	// DelVolumesAttachments specifies next step as deleting volume attachments
+	DelVolumesAttachments = "Delete Volume Attachments"
+
+	// InitiateVMDeletion specifies next step as initiate VM deletion
+	InitiateVMDeletion = "Initiate VM deletion"
+
+	// InitiateNodeDeletion specifies next step as node object deletion
+	InitiateNodeDeletion = "Initiate node object deletion"
+
+	// InitiateFinalizerRemoval specifies next step as machine finalizer removal
+	InitiateFinalizerRemoval = "Initiate machine object finalizer removal"
+
+	// LastAppliedALTAnnotation contains the last configuration of annotations, labels & taints applied on the node object
+	LastAppliedALTAnnotation = "node.machine.sapcloud.io/last-applied-anno-labels-taints"
+
+	// MachinePriority is the annotation used to specify priority
+	// associated with a machine while deleting it. The less its
+	// priority the more likely it is to be deleted first
+	// Default priority for a machine is set to 3
+	MachinePriority = "machinepriority.machine.sapcloud.io"
+
+	// MachineClassKind is used to identify the machineClassKind for generic machineClasses
+	MachineClassKind = "MachineClass"
+
+	// NotManagedByMCM annotation helps in identifying the nodes which are not handled by MCM
+	NotManagedByMCM = "node.machine.sapcloud.io/not-managed-by-mcm"
+
+	// TriggerDeletionByMCM annotation on the node would trigger the deletion of the corresponding machine object in the control cluster
+	TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"
+
+	// NodeUnhealthy is a node termination reason for failed machines
+	NodeUnhealthy = "Unhealthy"
+
+	// NodeScaledDown is a node termination reason for healthy deleted machines
+	NodeScaledDown = "ScaleDown"
+
+	// NodeTerminationCondition describes nodes that are terminating
+	NodeTerminationCondition v1.NodeConditionType = "Terminating"
+
+	// TaintNodeCriticalComponentsNotReady is the name of a gardener taint
+	// indicating that a node is not yet ready to have user workload scheduled
+	TaintNodeCriticalComponentsNotReady = "node.gardener.cloud/critical-components-not-ready"
+)
+
+// RetryPeriod is an alias for specifying the retry period
+type RetryPeriod time.Duration
+
+// These are the valid values for RetryPeriod
+const (
+	// ConflictRetry tells the controller to retry quickly - 200 milliseconds
+	ConflictRetry RetryPeriod = RetryPeriod(200 * time.Millisecond)
+	// ShortRetry tells the controller to retry after a short duration - 15 seconds
+	ShortRetry RetryPeriod = RetryPeriod(5 * time.Second)
+	// MediumRetry tells the controller to retry after a medium duration - 2 minutes
+	MediumRetry RetryPeriod = RetryPeriod(3 * time.Minute)
+	// LongRetry tells the controller to retry after a long duration - 10 minutes
+	LongRetry RetryPeriod = RetryPeriod(10 * time.Minute)
+)
+
+// EssentialTaints are taints on node object which if added/removed, require an immediate reconcile by machine controller
+// TODO: update this when taints for ALT updation and PostCreate operations is introduced.
+var EssentialTaints = []string{TaintNodeCriticalComponentsNotReady}

--- a/cluster-autoscaler/vendor/modules.txt
+++ b/cluster-autoscaler/vendor/modules.txt
@@ -252,6 +252,7 @@ github.com/gardener/machine-controller-manager/pkg/client/informers/externalvers
 github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1
 github.com/gardener/machine-controller-manager/pkg/util/provider/cache
 github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes
+github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils
 # github.com/gardener/machine-controller-manager-provider-aws v0.20.0
 ## explicit; go 1.21
 github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issues noticed in live issues 6120 and 6101. We introduce a mutex in the `NodeGroupImpl` struct (node group implementation) which must be acquired before performing a scale-down or scale-up operation. 

We also introduce an annotation on the MachineDeployment `TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"` whose value denotes the machines CA wants to remove and then atomically update replica count and annotation as one single step. This will help recognize machines for which CA has already reduced the replicas of the `MachineDeployment` and prevent it from being duplicated -  race conditions are avoided when CA scaledowns are occurring in parallel. The MCM is also updated to check this `TriggerDeletionByMCM` annotation on the `MachineDeployment`. 

The CA no longer directly sets the `MachinePriority=1` annotation on the `Machine` objects. This is now done by the MCM controller when reconciling the updated `MachineDeployment`.

**Which issue(s) this PR fixes**:
Fixes #342

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix for data-races in concurrent CA scaledowns and CA restarts
```
