### PR TITLE
[cherry-pick-v1.30] Fix Race conditions in Targeted Deletion of machines by CA (#341)

### DIFF
--- a/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils/utils.go
+++ b/cluster-autoscaler/vendor/github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils/utils.go
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Package machineutils contains the consts and global vaariables for machine operation
+package machineutils
+
+import (
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// GetVMStatus sets machine status to terminating and specifies next step as getting VMs
+	GetVMStatus = "Set machine status to termination. Now, getting VM Status"
+
+	// InstanceInitialization is a step that represents initialization of a VM instance (post-creation).
+	InstanceInitialization = "Initialize VM Instance"
+
+	// InitiateDrain specifies next step as initiate node drain
+	InitiateDrain = "Initiate node drain"
+
+	// DelVolumesAttachments specifies next step as deleting volume attachments
+	DelVolumesAttachments = "Delete Volume Attachments"
+
+	// InitiateVMDeletion specifies next step as initiate VM deletion
+	InitiateVMDeletion = "Initiate VM deletion"
+
+	// InitiateNodeDeletion specifies next step as node object deletion
+	InitiateNodeDeletion = "Initiate node object deletion"
+
+	// InitiateFinalizerRemoval specifies next step as machine finalizer removal
+	InitiateFinalizerRemoval = "Initiate machine object finalizer removal"
+
+	// LastAppliedALTAnnotation contains the last configuration of annotations, labels & taints applied on the node object
+	LastAppliedALTAnnotation = "node.machine.sapcloud.io/last-applied-anno-labels-taints"
+
+	// MachinePriority is the annotation used to specify priority
+	// associated with a machine while deleting it. The less its
+	// priority the more likely it is to be deleted first
+	// Default priority for a machine is set to 3
+	MachinePriority = "machinepriority.machine.sapcloud.io"
+
+	// MachineClassKind is used to identify the machineClassKind for generic machineClasses
+	MachineClassKind = "MachineClass"
+
+	// NotManagedByMCM annotation helps in identifying the nodes which are not handled by MCM
+	NotManagedByMCM = "node.machine.sapcloud.io/not-managed-by-mcm"
+
+	// TriggerDeletionByMCM annotation on the node would trigger the deletion of the corresponding machine object in the control cluster
+	TriggerDeletionByMCM = "node.machine.sapcloud.io/trigger-deletion-by-mcm"
+
+	// NodeUnhealthy is a node termination reason for failed machines
+	NodeUnhealthy = "Unhealthy"
+
+	// NodeScaledDown is a node termination reason for healthy deleted machines
+	NodeScaledDown = "ScaleDown"
+
+	// NodeTerminationCondition describes nodes that are terminating
+	NodeTerminationCondition v1.NodeConditionType = "Terminating"
+
+	// TaintNodeCriticalComponentsNotReady is the name of a gardener taint
+	// indicating that a node is not yet ready to have user workload scheduled
+	TaintNodeCriticalComponentsNotReady = "node.gardener.cloud/critical-components-not-ready"
+)
+
+// RetryPeriod is an alias for specifying the retry period
+type RetryPeriod time.Duration
+
+// These are the valid values for RetryPeriod
+const (
+	// ConflictRetry tells the controller to retry quickly - 200 milliseconds
+	ConflictRetry RetryPeriod = RetryPeriod(200 * time.Millisecond)
+	// ShortRetry tells the controller to retry after a short duration - 15 seconds
+	ShortRetry RetryPeriod = RetryPeriod(5 * time.Second)
+	// MediumRetry tells the controller to retry after a medium duration - 2 minutes
+	MediumRetry RetryPeriod = RetryPeriod(3 * time.Minute)
+	// LongRetry tells the controller to retry after a long duration - 10 minutes
+	LongRetry RetryPeriod = RetryPeriod(10 * time.Minute)
+)
+
+// EssentialTaints are taints on node object which if added/removed, require an immediate reconcile by machine controller
+// TODO: update this when taints for ALT updation and PostCreate operations is introduced.
+var EssentialTaints = []string{TaintNodeCriticalComponentsNotReady}

--- a/cluster-autoscaler/vendor/modules.txt
+++ b/cluster-autoscaler/vendor/modules.txt
@@ -252,6 +252,7 @@ github.com/gardener/machine-controller-manager/pkg/client/informers/externalvers
 github.com/gardener/machine-controller-manager/pkg/client/listers/machine/v1alpha1
 github.com/gardener/machine-controller-manager/pkg/util/provider/cache
 github.com/gardener/machine-controller-manager/pkg/util/provider/machinecodes/codes
+github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils
 # github.com/gardener/machine-controller-manager-provider-aws v0.20.0
 ## explicit; go 1.21
 github.com/gardener/machine-controller-manager-provider-aws/pkg/aws/apis


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR cherry picks the the following commit: [`edd7d34d`](https://github.com/gardener/autoscaler/commit/edd7d34dfba73f68e6f4d2516bb3212e92732040)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix for data-races in concurrent CA scaledowns and CA restarts
```
