### PR TITLE
Adapt pipeline_definition to include SAST linting logs in OCM descriptor

### DIFF
--- a/.ci/check
+++ b/.ci/check
@@ -47,4 +47,5 @@ go get -u golang.org/x/lint/golint
 PACKAGES="$(go list -e ./... | grep -vE '/tmp/|/vendor/')"
 LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|k8s.io/autoscaler/cluster-autoscaler|.|g")"
 
-#TODO: To add lint checking, after fixing issues
+# Run Static Application Security Testing (SAST) using gosec
+make sast-report

--- a/.ci/check
+++ b/.ci/check
@@ -38,9 +38,9 @@ if [[ "${SOURCE_PATH}" != *"src/k8s.io/autoscaler" ]]; then
   export PATH="${GOBIN}:${PATH}"
 fi
 
-# Install Golint (linting tool).
-go get -u github.com/golang/lint/golint
-go get -u golang.org/x/lint/golint
+# Install golangci-lint (linting tool).
+GOLANGCI_LINT_VERSION=v1.60.3
+go install github.com/golangci/golangci-lint/cmd/golangci-lint@"${GOLANGCI_LINT_VERSION}"
 
 ###############################################################################
 
@@ -48,4 +48,4 @@ PACKAGES="$(go list -e ./... | grep -vE '/tmp/|/vendor/')"
 LINT_FOLDERS="$(echo ${PACKAGES} | sed "s|k8s.io/autoscaler/cluster-autoscaler|.|g")"
 
 # Run Static Application Security Testing (SAST) using gosec
-make sast-report
+make sast-report -C cluster-autoscaler

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -2,17 +2,11 @@ autoscaler:
   base_definition:
     repo:
       source_labels:
-      - name: 'cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1'
+      - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
         value:
-          policy: 'scan'
-          path_config:
-            exclude_paths:
-              - '.*/aws-sdk-go/.*'
-              - '^vendor/.*'
-              - '.*/vendor/.*'
-              - '.*/cloudprovider/((?!mcm/).)*/.*'
-              - '^addon-resizer/.*'
-              - '^vertical-pod-autoscaler/.*'
+          policy: skip
+          comment: |
+            we use gosec for sast scanning. See attached log.
     traits:
       version:
         preprocess:
@@ -62,6 +56,16 @@ autoscaler:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/autoscaler/cluster-autoscaler
         release:
           nextversion: 'bump_minor'
+          assets:
+            - type: build-step-log
+              step_name: check
+              purposes:
+                - lint
+                - sast
+                - gosec
+              comment: |
+                we use gosec (linter) for SAST scans
+                see: https://github.com/securego/gosec
         slack:
           default_channel: 'internal_scp_workspace'
           channel_cfgs:

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -31,6 +31,8 @@ autoscaler:
     steps:
       test:
         image: 'golang:1.22.2'
+      check:
+        image: 'golang:1.22.2'
       build:
         image: 'golang:1.22.2'
         output_dir: 'binary'

--- a/cluster-autoscaler/.gitignore
+++ b/cluster-autoscaler/.gitignore
@@ -12,3 +12,6 @@ Session.vim
 .netrwhist
 .vscode
 ./integration/logs
+
+# gosec
+gosec-report.sarif

--- a/cluster-autoscaler/cloudprovider/utils.go
+++ b/cluster-autoscaler/cloudprovider/utils.go
@@ -77,7 +77,7 @@ func BuildKubeProxy(name string) *apiv1.Pod {
 	priority := scheduling.SystemCriticalPriority
 	return &apiv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("kube-proxy-%s-%d", name, rand.Int63()),
+			Name:      fmt.Sprintf("kube-proxy-%s-%d", name, rand.Int63()), // #nosec G404 (CWE-338) -- code inherited from upstream
 			Namespace: "kube-system",
 			Annotations: map[string]string{
 				kubetypes.ConfigSourceAnnotationKey: kubetypes.FileSource,

--- a/cluster-autoscaler/hack/sast.sh
+++ b/cluster-autoscaler/hack/sast.sh
@@ -43,6 +43,7 @@ dir_to_exclude="-exclude-dir=cloudprovider/alicloud
 -exclude-dir=cloudprovider/baiducloud
 -exclude-dir=cloudprovider/bizflycloud
 -exclude-dir=cloudprovider/brightbox
+-exclude-dir=cloudprovider/builder
 -exclude-dir=cloudprovider/cherryservers
 -exclude-dir=cloudprovider/civo
 -exclude-dir=cloudprovider/cloudstack
@@ -50,6 +51,7 @@ dir_to_exclude="-exclude-dir=cloudprovider/alicloud
 -exclude-dir=cloudprovider/digitalocean
 -exclude-dir=cloudprovider/equinixmetal
 -exclude-dir=cloudprovider/exoscale
+-exclude-dir=cloudprovider/externalgrpc
 -exclude-dir=cloudprovider/gce
 -exclude-dir=cloudprovider/hetzner
 -exclude-dir=cloudprovider/huaweicloud
@@ -66,6 +68,24 @@ dir_to_exclude="-exclude-dir=cloudprovider/alicloud
 -exclude-dir=cloudprovider/tencentcloud
 -exclude-dir=cloudprovider/volcengine
 -exclude-dir=cloudprovider/vultr
+-exclude-dir=apis
+-exclude-dir=cluster-state
+-exclude-dir=config
+-exclude-dir=context
+-exclude-dir=core
+-exclude-dir=debuggingsnapshot
+-exclude-dir=estimator
+-exclude-dir=expander
+-exclude-dir=hack
+-exclude-dir=loop
+-exclude-dir=metrics
+-exclude-dir=observers
+-exclude-dir=processors
+-exclude-dir=proposals
+-exclude-dir=provisioningrequest
+-exclude-dir=simulator
+-exclude-dir=util
+-exclude-dir=version
 "
 
 ${TOOLS_BIN_DIR}/gosec -exclude-generated $dir_to_exclude $gosec_report_parse_flags ./...

--- a/cluster-autoscaler/integration/framework.go
+++ b/cluster-autoscaler/integration/framework.go
@@ -64,12 +64,12 @@ func rotateLogFile(fileName string) (*os.File, error) {
 
 	if _, err := os.Stat(fileName); err == nil { // !strings.Contains(err.Error(), "no such file or directory") {
 		for i := 9; i > 0; i-- {
-			os.Rename(fmt.Sprintf("%s.%d", fileName, i), fmt.Sprintf("%s.%d", fileName, i+1))
+			_ = os.Rename(fmt.Sprintf("%s.%d", fileName, i), fmt.Sprintf("%s.%d", fileName, i+1))
 		}
-		os.Rename(fileName, fmt.Sprintf("%s.%d", fileName, 1))
+		_ = os.Rename(fileName, fmt.Sprintf("%s.%d", fileName, 1))
 	}
 
-	return os.Create(fileName)
+	return os.Create(fileName) //#nosec G304 (CWE-22) -- this is used only for tests. Cannot be exploited
 }
 
 func (driver *Driver) addTaintsToInitialNodes() error {
@@ -135,7 +135,7 @@ func (driver *Driver) adjustNodeGroups() error {
 }
 
 // getNumberOfReadyNodes tries to retrieve the list of node objects in the cluster.
-func (c *Cluster) getNumberOfReadyNodes() int16 {
+func (c *Cluster) getNumberOfReadyNodes() int {
 	nodes, _ := c.Clientset.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
 	count := 0
 	for _, n := range nodes.Items {
@@ -146,7 +146,7 @@ func (c *Cluster) getNumberOfReadyNodes() int16 {
 			}
 		}
 	}
-	return int16(count)
+	return count
 }
 
 func (driver *Driver) scaleAutoscaler(replicas int32) error {
@@ -206,7 +206,7 @@ func (driver *Driver) runAutoscaler() {
 
 	outputFile, err := rotateLogFile(CALogFile)
 	gom.Expect(err).ShouldNot(gom.HaveOccurred())
-	autoscalerSession, err = gexec.Start(exec.Command(args[0], args[1:]...), outputFile, outputFile)
+	autoscalerSession, err = gexec.Start(exec.Command(args[0], args[1:]...), outputFile, outputFile) //#nosec G204 (CWE-78) -- this is used only for tests. Cannot be exploited
 	gom.Expect(err).ShouldNot(gom.HaveOccurred())
 	gom.Expect(autoscalerSession.ExitCode()).Should(gom.Equal(-1))
 }

--- a/cluster-autoscaler/main.go
+++ b/cluster-autoscaler/main.go
@@ -669,7 +669,7 @@ func main() {
 		if *enableProfiling {
 			routes.Profiling{}.Install(pathRecorderMux)
 		}
-		err := http.ListenAndServe(*address, pathRecorderMux)
+		err := http.ListenAndServe(*address, pathRecorderMux) // #nosec G114 (CWE-676) -- code inherited from upstream
 		klog.Fatalf("Failed to start metrics: %v", err)
 	}()
 


### PR DESCRIPTION
**What this PR does / why we need it**:
The PR does the following
- changes pipeline_definitions to include SAST linting logs in OCM descriptor.
- Fixes some security vulnerabilities 
- Updated the `check` make command to run sast

**Which issue(s) this PR fixes**:
Fixes #331 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
