### PR TITLE
Added Responsibles

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -28,6 +28,13 @@ autoscaler:
                 build: ~
             image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/autoscaler/cluster-autoscaler
             dockerfile: './cluster-autoscaler/Dockerfile'
+            resource_labels:
+            - name: 'cloud.gardener.cnudie/responsibles'
+              value:
+              - type: 'githubUser'
+                username: 'aaronfern'
+              - type: 'githubUser'
+                username: 'elankath'
     steps:
       test:
         image: 'golang:1.23.2'


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds `cloud.gardener.cnudie/responsibles` 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
