### PR TITLE
Add labels to BasicIgnoredLabels to fix similarity check 

### DIFF
--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -34,16 +34,16 @@ const (
 	LabelWorkerPool = "worker.gardener.cloud/pool"
 	// LabelWorkerPoolDeprecated is a deprecated constant for a label that indicates the worker pool the node belongs to
 	LabelWorkerPoolDeprecated = "worker.garden.sapcloud.io/group"
+	// LabelMachineName adds the name of the machine to the node
+	LabelMachineName = "node.gardener.cloud/machine-name"
 	// LabelTopologyEBSCSIAWS is a CSI-specific label for ebs-driver in AWS.
 	LabelTopologyEBSCSIAWS = "topology.ebs.csi.aws.com/zone"
 	// LabelTopologyGKE is a CSI-specific label for persistent disk driver in GCP.
 	LabelTopologyGKE = "topology.gke.io/zone"
 	// LabelTopologyDiskCSIAzure is a CSI-specific label for disk driver in Azure.
 	LabelTopologyDiskCSIAzure = "topology.disk.csi.azure.com/zone"
-	// LabelAWSZoneID indicates the zone-id of the node in AWS
-	LabelAWSZoneID = "topology.k8s.aws/zone-id"
-	// LabelMachineName adds the name of the machine to the node
-	LabelMachineName = "node.gardener.cloud/machine-name"
+	// LabelTopologyAWSZoneID indicates the zone-id of the node in AWS
+	LabelTopologyAWSZoneID = "topology.k8s.aws/zone-id"
 	// LabelTopologyDiskPluginCSIAlibabaCloud is a CSI-specific label for disk plugin in Alibaba Cloud
 	LabelTopologyDiskPluginCSIAlibabaCloud = "topology.diskplugin.csi.alibabacloud"
 	// LabelECSInstanceID is the instance ID in Alibaba Cloud
@@ -76,7 +76,7 @@ var BasicIgnoredLabels = map[string]bool{
 	LabelTopologyEBSCSIAWS:                 true,
 	LabelTopologyGKE:                       true,
 	LabelTopologyDiskCSIAzure:              true,
-	LabelAWSZoneID:                         true,
+	LabelTopologyAWSZoneID:                 true,
 	LabelTopologyDiskPluginCSIAlibabaCloud: true,
 	LabelTopologyCinderCSIOpenStack:        true,
 	LabelTopologyManilaCSIOpenStack:        true,

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -40,6 +40,10 @@ const (
 	LabelTopologyGKE = "topology.gke.io/zone"
 	// LabelTopologyDiskCSIAzure is a CSI-specific label for disk driver in Azure.
 	LabelTopologyDiskCSIAzure = "topology.disk.csi.azure.com/zone"
+	// LabelAWSZoneID indicates the zone-id of the node in AWS
+	LabelAWSZoneID = "topology.k8s.aws/zone-id"
+	// LabelMachineName adds the name of the machine to the node
+	LabelMachineName = "node.gardener.cloud/machine-name"
 )
 
 // BasicIgnoredLabels define a set of basic labels that should be ignored when comparing the similarity
@@ -62,6 +66,8 @@ var BasicIgnoredLabels = map[string]bool{
 	LabelTopologyEBSCSIAWS:    true,
 	LabelTopologyGKE:          true,
 	LabelTopologyDiskCSIAzure: true,
+	LabelAWSZoneID:            true,
+	LabelMachineName:          true,
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups

--- a/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
+++ b/cluster-autoscaler/processors/nodegroupset/compare_nodegroups.go
@@ -44,6 +44,14 @@ const (
 	LabelAWSZoneID = "topology.k8s.aws/zone-id"
 	// LabelMachineName adds the name of the machine to the node
 	LabelMachineName = "node.gardener.cloud/machine-name"
+	// LabelTopologyDiskPluginCSIAlibabaCloud is a CSI-specific label for disk plugin in Alibaba Cloud
+	LabelTopologyDiskPluginCSIAlibabaCloud = "topology.diskplugin.csi.alibabacloud"
+	// LabelECSInstanceID is the instance ID in Alibaba Cloud
+	LabelECSInstanceID = "alibabacloud.com/ecs-instance-id"
+	// LabelTopologyCinderCSIOpenStack is a CSI-specific label for cinder-driver in OpenStack
+	LabelTopologyCinderCSIOpenStack = "topology.cinder.csi.openstack.org/zone"
+	// LabelTopologyManilaCSIOpenStack is a CSI-specific label for manila-driver in OpenStack
+	LabelTopologyManilaCSIOpenStack = "topology.manila.csi.openstack.org/zone"
 )
 
 // BasicIgnoredLabels define a set of basic labels that should be ignored when comparing the similarity
@@ -62,12 +70,19 @@ var BasicIgnoredLabels = map[string]bool{
 	LabelWorkerPool:              false,
 	LabelWorkerPoolDeprecated:    false,
 	LabelWorkerKubernetesVersion: true,
+	LabelMachineName:             true,
+
 	// Ignore CSI specific labels.
-	LabelTopologyEBSCSIAWS:    true,
-	LabelTopologyGKE:          true,
-	LabelTopologyDiskCSIAzure: true,
-	LabelAWSZoneID:            true,
-	LabelMachineName:          true,
+	LabelTopologyEBSCSIAWS:                 true,
+	LabelTopologyGKE:                       true,
+	LabelTopologyDiskCSIAzure:              true,
+	LabelAWSZoneID:                         true,
+	LabelTopologyDiskPluginCSIAlibabaCloud: true,
+	LabelTopologyCinderCSIOpenStack:        true,
+	LabelTopologyManilaCSIOpenStack:        true,
+
+	// Ignore Alibaba Cloud instance-id
+	LabelECSInstanceID: true,
 }
 
 // NodeInfoComparator is a function that tells if two nodes are from NodeGroups


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug which made CA treat similar node groups as dissimilar, resulting in imbalanced scale ups across zones. The PR adds the following labels to `BasicIgnoredLabels`:
```
topology.k8s.aws/zone-id
node.gardener.cloud/machine-name
topology.diskplugin.csi.alibabacloud
alibabacloud.com/ecs-instance-id
topology.cinder.csi.openstack.org/zone
topology.manila.csi.openstack.org/zone
```

The values for these labels will be ignored during the similarity check. Hence, two node templates with differing values for these labels can still be considered "similar" if other similarity checks pass.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Unit tests and integration tests (aws) passed. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed bug that causes CA to treat two similar nodegroups as dissimilar due to missing labels in `BasicIgnoredLabels`. 
```
