### PR TITLE
Modify `AppsSharedInformer` to only fetch deployments restricted to namespace

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -217,7 +217,7 @@ func createMCMManagerInternal(discoveryOpts cloudprovider.NodeGroupDiscoveryOpti
 	}
 
 	controlAppsClient := controlClientBuilder.ClientOrDie("control-apps-client")
-	appsInformerFactory := appsinformers.NewSharedInformerFactory(controlAppsClient, *minResyncPeriod)
+	appsInformerFactory := appsinformers.NewFilteredSharedInformerFactory(controlAppsClient, *minResyncPeriod, namespace, nil)
 	deploymentLister := appsInformerFactory.Apps().V1().Deployments().Lister()
 
 	if availableResources[machineGVR] && availableResources[machineSetGVR] && availableResources[machineDeploymentGVR] {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -217,7 +217,7 @@ func createMCMManagerInternal(discoveryOpts cloudprovider.NodeGroupDiscoveryOpti
 	}
 
 	controlAppsClient := controlClientBuilder.ClientOrDie("control-apps-client")
-	appsInformerFactory := appsinformers.NewFilteredSharedInformerFactory(controlAppsClient, *minResyncPeriod, namespace, nil)
+	appsInformerFactory := appsinformers.NewSharedInformerFactoryWithOptions(controlAppsClient, *minResyncPeriod, appsinformers.WithNamespace(namespace))
 	deploymentLister := appsInformerFactory.Apps().V1().Deployments().Lister()
 
 	if availableResources[machineGVR] && availableResources[machineSetGVR] && availableResources[machineDeploymentGVR] {
@@ -230,11 +230,10 @@ func createMCMManagerInternal(discoveryOpts cloudprovider.NodeGroupDiscoveryOpti
 		controlMachineClientBuilder := MachineControllerClientBuilder{
 			ClientConfig: controlKubeconfig,
 		}
-		controlMachineInformerFactory := machineinformers.NewFilteredSharedInformerFactory(
+		controlMachineInformerFactory := machineinformers.NewSharedInformerFactoryWithOptions(
 			controlMachineClientBuilder.ClientOrDie("control-machine-shared-informers"),
 			*minResyncPeriod,
-			namespace,
-			nil,
+			machineinformers.WithNamespace(namespace),
 		)
 
 		controlMachineClient := controlMachineClientBuilder.ClientOrDie("control-machine-client").MachineV1alpha1()

--- a/cluster-autoscaler/cloudprovider/mcm/test_utils.go
+++ b/cluster-autoscaler/cloudprovider/mcm/test_utils.go
@@ -6,11 +6,12 @@ package mcm
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	appsv1 "k8s.io/api/apps/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
-	"testing"
-	"time"
 
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/client-go/tools/cache"
@@ -239,30 +240,27 @@ func createMcmManager(
 		controlAppsObjectTracker,
 	)
 	fakeObjectTrackers.Start()
-	coreTargetInformerFactory := coreinformers.NewFilteredSharedInformerFactory(
+	coreTargetInformerFactory := coreinformers.NewSharedInformerFactoryWithOptions(
 		fakeTargetCoreClient,
 		100*time.Millisecond,
-		namespace,
-		nil,
+		coreinformers.WithNamespace(namespace),
 	)
 	defer coreTargetInformerFactory.Start(stop)
 	coreTargetSharedInformers := coreTargetInformerFactory.Core().V1()
 	nodes := coreTargetSharedInformers.Nodes()
 
-	appsControlInformerFactory := appsv1informers.NewFilteredSharedInformerFactory(
+	appsControlInformerFactory := appsv1informers.NewSharedInformerFactoryWithOptions(
 		fakeControlAppsClient,
 		100*time.Millisecond,
-		namespace,
-		nil,
+		appsv1informers.WithNamespace(namespace),
 	)
 	defer appsControlInformerFactory.Start(stop)
 	appsControlSharedInformers := appsControlInformerFactory.Apps().V1()
 
-	controlMachineInformerFactory := machineinformers.NewFilteredSharedInformerFactory(
+	controlMachineInformerFactory := machineinformers.NewSharedInformerFactoryWithOptions(
 		fakeControlMachineClient,
 		100*time.Millisecond,
-		namespace,
-		nil,
+		machineinformers.WithNamespace(namespace),
 	)
 	defer controlMachineInformerFactory.Start(stop)
 


### PR DESCRIPTION
**Why need a PR**:
The changes made in the PR will be relevant when changes to use `Role/RoleBinding` to provide RBAC permissions to the CA pod instead of `ClusterRole/ClusterRoleBinding` are added. 
Using `NewSharedInformerFactory` in the mcm cloud provider results in an error of not being able to list resources at the cluster scope when `ClusterRole` permissions are removed.
```
E0903 20:30:07.362326       1 reflector.go:200] "Failed to watch" err="failed to list *v1.Deployment: deployments.apps is forbidden: User \"system:serviceaccount:shoot--local--local:cluster-autoscaler\" cannot list resource \"deployments\" in API group \"apps\" at the cluster scope" logger="UnhandledError" reflector="pkg/mod/k8s.io/client-go@v0.33.0/tools/cache/reflector.go:285" type="*v1.Deployment"
I0903 20:30:10.349752       1 static_autoscaler.go:275] Starting main loop
I0903 20:30:10.349880       1 taints.go:443] Overriding status of node machine-shoot--local--local-local-68499-h4f99, which seems to have startup taint "node.gardener.cloud/critical-components-not-ready"
I0903 20:30:10.349921       1 static_autoscaler.go:1174] Found 18 pods in the cluster: 7 scheduled, 11 unschedulable, 0 unprocessed by scheduler, 0 ignored (most likely using custom scheduler)
E0903 20:30:10.349973       1 static_autoscaler.go:326] Failed to refresh cloud provider config: failed to get machine-controller-manager deployment: deployment.apps "machine-controller-manager" not found
```
**What this PR does**:
This function has been replaced by [NewSharedInformerFactoryWithOptions](https://pkg.go.dev/k8s.io/client-go/informers#NewSharedInformerFactoryWithOptions), which accepts namespace as an argument. 

As a result, only deployments within the specified namespace those for which the CA service account has the necessary permissions are fetched, rather than cluster-wide deployments that the service account is not authorized to access.

Additionally, as a similar function `NewFilteredSharedInformerFactory` has been [deprecated](https://pkg.go.dev/k8s.io/client-go/informers#NewFilteredSharedInformerFactory), it is replaced with `NewSharedInformerFactoryWithOptions` (for `machineinformers`)

<!--
**Special notes for your reviewer**:
----Tests----
-->
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Use namespace scoped `NewSharedInformerFactoryWithOptions` function instead of `NewSharedInformerFactory` to restrict Deployment Lister
```
