### PR TITLE
Fixing the issue where a rapid scale up and scale down can result in a cordoned machine in the cluster

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -584,7 +584,7 @@ func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []stri
 	for _, machineNameWithTimestamp := range machineNamesWithTimestamps {
 		parts := strings.Split(machineNameWithTimestamp, "~")
 		if len(parts) != 2 {
-			klog.Errorf("Unexpected format for machineNameWithTimestamp %q in annotation %q of MachineDeployment %q, expected format is <machineName>~<timestamp>", machineNameWithTimestamp, machineutils.TriggerDeletionByMCM, mcd.Name)
+			klog.Errorf("unexpected format for machineNameWithTimestamp %q in annotation %q of MachineDeployment %q, expected format is <machineName>~<timestamp>", machineNameWithTimestamp, machineutils.TriggerDeletionByMCM, mcd.Name)
 			continue
 		}
 		machineNames = append(machineNames, parts[0])

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -575,7 +575,6 @@ func (ngImpl *nodeGroup) AtomicIncreaseSize(delta int) error {
 }
 
 // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
-// TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
 func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
 	if mcd == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
 		return nil
@@ -583,17 +582,19 @@ func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []stri
 	machineNamesWithTimestamps := strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
 	machineNames := make([]string, 0, len(machineNamesWithTimestamps))
 	for _, machineNameWithTimestamp := range machineNamesWithTimestamps {
-		machineNames = append(machineNames, strings.Split(machineNameWithTimestamp, "~")[0])
+		parts := strings.Split(machineNameWithTimestamp, "~")
+		if len(parts) != 2 {
+			klog.Errorf("Unexpected format for machineNameWithTimestamp %q in annotation %q of MachineDeployment %q, expected format is <machineName>~<timestamp>", machineNameWithTimestamp, machineutils.TriggerDeletionByMCM, mcd.Name)
+			continue
+		}
+		machineNames = append(machineNames, parts[0])
 	}
 	return machineNames
 }
 
-// TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
-func createMachinesTriggeredForDeletionAnnotValue(mcd *v1alpha1.MachineDeployment, machineNames []string) string {
-	timestamp := time.Now().Format(time.RFC3339)
+// createMachinesTriggeredForDeletionAnnotValue creates the value for the machineutils.TriggerDeletionByMCM annotation based on the given machine names and timestamp.
+// The format of the returned string is expected to be <machineName1>~<timestamp>,<machineName2>~<timestamp>...
+func createMachinesTriggeredForDeletionAnnotValue(machineNames []string, timestamp string) string {
 	slices.Sort(machineNames)
-	if mcd != nil && mcd.Annotations[machineutils.TriggerDeletionByMCM] != "" {
-		return mcd.Annotations[machineutils.TriggerDeletionByMCM] + "," + strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
-	}
 	return strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -577,7 +577,7 @@ func (ngImpl *nodeGroup) AtomicIncreaseSize(delta int) error {
 // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
 // TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
 func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
-	if mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
+	if mcd == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
 		return nil
 	}
 	machineNamesWithTimestamps := strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
@@ -592,9 +592,8 @@ func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []stri
 func createMachinesTriggeredForDeletionAnnotValue(mcd *v1alpha1.MachineDeployment, machineNames []string) string {
 	timestamp := time.Now().Format(time.RFC3339)
 	slices.Sort(machineNames)
-	annotationValue := ""
-	if mcd.Annotations[machineutils.TriggerDeletionByMCM] != "" {
-		return annotationValue + "," + strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
+	if mcd != nil && mcd.Annotations[machineutils.TriggerDeletionByMCM] != "" {
+		return mcd.Annotations[machineutils.TriggerDeletionByMCM] + "," + strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
 	}
 	return strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -577,14 +577,24 @@ func (ngImpl *nodeGroup) AtomicIncreaseSize(delta int) error {
 // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
 // TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
 func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
-	if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
+	if mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
 		return nil
 	}
-	return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
+	machineNamesWithTimestamps := strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
+	machineNames := make([]string, 0, len(machineNamesWithTimestamps))
+	for _, machineNameWithTimestamp := range machineNamesWithTimestamps {
+		machineNames = append(machineNames, strings.Split(machineNameWithTimestamp, "~")[0])
+	}
+	return machineNames
 }
 
 // TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
-func createMachinesTriggeredForDeletionAnnotValue(machineNames []string) string {
+func createMachinesTriggeredForDeletionAnnotValue(mcd *v1alpha1.MachineDeployment, machineNames []string) string {
+	timestamp := time.Now().Format(time.RFC3339)
 	slices.Sort(machineNames)
-	return strings.Join(machineNames, ",")
+	annotationValue := ""
+	if mcd.Annotations[machineutils.TriggerDeletionByMCM] != "" {
+		return annotationValue + "," + strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
+	}
+	return strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -583,7 +583,7 @@ func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []stri
 	machineNames := make([]string, 0, len(machineNamesWithTimestamps))
 	for _, machineNameWithTimestamp := range machineNamesWithTimestamps {
 		parts := strings.Split(machineNameWithTimestamp, "~")
-		if len(parts) != 2 {
+		if len(parts) != 1 && len(parts) != 2 {
 			klog.Errorf("unexpected format for machineNameWithTimestamp %q in annotation %q of MachineDeployment %q, expected format is <machineName>~<timestamp>", machineNameWithTimestamp, machineutils.TriggerDeletionByMCM, mcd.Name)
 			continue
 		}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 
 	v1 "k8s.io/api/apps/v1"
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -87,9 +87,11 @@ func TestDeleteNodes(t *testing.T) {
 		node *corev1.Node
 	}
 	type expect struct {
-		mdName     string
-		mdReplicas int32
-		err        error
+		prio1Machines                          []*v1alpha1.Machine
+		mdName                                 string
+		mdReplicas                             int32
+		machinesTriggerDeletionAnnotationValue string
+		err                                    error
 	}
 	type data struct {
 		name   string
@@ -109,9 +111,11 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        nil,
+				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				mdName:                                 "machinedeployment-1",
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1)),
+				mdReplicas:                             1,
+				err:                                    nil,
 			},
 		},
 		{
@@ -125,9 +129,11 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNode("node-1", "requested://machine-1")},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 0,
-				err:        nil,
+				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1)),
+				mdName:                                 "machinedeployment-1",
+				mdReplicas:                             0,
+				err:                                    nil,
 			},
 		},
 		{
@@ -136,22 +142,29 @@ func TestDeleteNodes(t *testing.T) {
 				nodes:       newNodes(2, "fakeID"),
 				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets: newMachineSets(2, "machinedeployment-1"),
-				nodeGroups:  []string{nodeGroup1},
+				machineDeployments: newMachineDeployments(1, 2, &v1alpha1.MachineDeploymentStatus{
+					Conditions: []v1alpha1.MachineDeploymentCondition{
+						{Type: "Progressing"},
+					},
+				}, nil, nil),
+				nodeGroups: []string{nodeGroup1},
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 2,
-				err:        fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-1",
+				mdReplicas:    2,
+				err:           fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
 			},
 		},
 		{
 			"should not scale down when machine deployment update call times out",
 			setup{
-				nodes:       newNodes(2, "fakeID"),
-				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
-				machineSets: newMachineSets(1, "machinedeployment-1"),
-				nodeGroups:  []string{nodeGroup1},
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
+				machineSets:        newMachineSets(1, "machinedeployment-1"),
+				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
+				nodeGroups:         []string{nodeGroup1},
 				controlMachineFakeResourceActions: &customfake.ResourceActions{
 					MachineDeployment: customfake.Actions{
 						Update: customfake.CreateFakeResponse(math.MaxInt32, mdUpdateErrorMsg, 0),
@@ -168,10 +181,11 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should scale down when machine deployment update call fails but passes within the timeout period",
 			setup{
-				nodes:       newNodes(2, "fakeID"),
-				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
-				machineSets: newMachineSets(1, "machinedeployment-1"),
-				nodeGroups:  []string{nodeGroup1},
+				nodes:              newNodes(2, "fakeID"),
+				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
+				machineSets:        newMachineSets(1, "machinedeployment-1"),
+				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
+				nodeGroups:         []string{nodeGroup1},
 				controlMachineFakeResourceActions: &customfake.ResourceActions{
 					MachineDeployment: customfake.Actions{
 						Update: customfake.CreateFakeResponse(2, mdUpdateErrorMsg, 0),
@@ -180,9 +194,11 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        nil,
+				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1)),
+				mdName:                                 "machinedeployment-1",
+				mdReplicas:                             1,
+				err:                                    nil,
 			},
 		},
 		{
@@ -228,9 +244,10 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        fmt.Errorf("min size reached, nodes will not be deleted"),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-1",
+				mdReplicas:    1,
+				err:           fmt.Errorf("min size reached, nodes will not be deleted"),
 			},
 		},
 		{
@@ -244,9 +261,10 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				mdName:     "machinedeployment-2",
-				mdReplicas: 2,
-				err:        fmt.Errorf("node-1 belongs to a different MachineDeployment than %q", "machinedeployment-1"),
+				prio1Machines: nil,
+				mdName:        "machinedeployment-2",
+				mdReplicas:    2,
+				err:           fmt.Errorf("node-1 belongs to a different MachineDeployment than %q", "machinedeployment-1"),
 			},
 		},
 	}
@@ -284,7 +302,7 @@ func TestDeleteNodes(t *testing.T) {
 			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
-			g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(machineDeployment, generateNames("machine", 1))))
+			g.Expect(strings.Split(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0]).To(Equal(strings.Split(entry.expect.machinesTriggerDeletionAnnotationValue, "~")[0]))
 		})
 	}
 }
@@ -315,7 +333,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), setupObj.machineDeployments[0].Name, metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", 2))
-	g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(machineDeployment, generateNames("machine", 1))))
+	g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1))))
 }
 
 func TestRefresh(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -113,7 +113,7 @@ func TestDeleteNodes(t *testing.T) {
 			expect{
 				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
 				mdName:                                 "machinedeployment-1",
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1)),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)),
 				mdReplicas:                             1,
 				err:                                    nil,
 			},
@@ -130,7 +130,7 @@ func TestDeleteNodes(t *testing.T) {
 			action{node: newNode("node-1", "requested://machine-1")},
 			expect{
 				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1)),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)),
 				mdName:                                 "machinedeployment-1",
 				mdReplicas:                             0,
 				err:                                    nil,
@@ -195,7 +195,7 @@ func TestDeleteNodes(t *testing.T) {
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
 				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1)),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)),
 				mdName:                                 "machinedeployment-1",
 				mdReplicas:                             1,
 				err:                                    nil,
@@ -333,7 +333,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), setupObj.machineDeployments[0].Name, metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", 2))
-	g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(nil, generateNames("machine", 1))))
+	g.Expect(strings.Split(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0]).To(Equal(strings.Split(createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)), "~")[0]))
 }
 
 func TestRefresh(t *testing.T) {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -87,11 +87,9 @@ func TestDeleteNodes(t *testing.T) {
 		node *corev1.Node
 	}
 	type expect struct {
-		prio1Machines                          []*v1alpha1.Machine
-		mdName                                 string
-		mdReplicas                             int32
-		machinesTriggerDeletionAnnotationValue string
-		err                                    error
+		mdName     string
+		mdReplicas int32
+		err        error
 	}
 	type data struct {
 		name   string
@@ -111,11 +109,9 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				mdName:                                 "machinedeployment-1",
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
-				mdReplicas:                             1,
-				err:                                    nil,
+				mdName:     "machinedeployment-1",
+				mdReplicas: 1,
+				err:        nil,
 			},
 		},
 		{
@@ -129,11 +125,9 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNode("node-1", "requested://machine-1")},
 			expect{
-				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
-				mdName:                                 "machinedeployment-1",
-				mdReplicas:                             0,
-				err:                                    nil,
+				mdName:     "machinedeployment-1",
+				mdReplicas: 0,
+				err:        nil,
 			},
 		},
 		{
@@ -142,29 +136,22 @@ func TestDeleteNodes(t *testing.T) {
 				nodes:       newNodes(2, "fakeID"),
 				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
 				machineSets: newMachineSets(2, "machinedeployment-1"),
-				machineDeployments: newMachineDeployments(1, 2, &v1alpha1.MachineDeploymentStatus{
-					Conditions: []v1alpha1.MachineDeploymentCondition{
-						{Type: "Progressing"},
-					},
-				}, nil, nil),
-				nodeGroups: []string{nodeGroup1},
+				nodeGroups:  []string{nodeGroup1},
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				prio1Machines: nil,
-				mdName:        "machinedeployment-1",
-				mdReplicas:    2,
-				err:           fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
+				mdName:     "machinedeployment-1",
+				mdReplicas: 2,
+				err:        fmt.Errorf("MachineDeployment machinedeployment-1 is under rolling update , cannot reduce replica count"),
 			},
 		},
 		{
 			"should not scale down when machine deployment update call times out",
 			setup{
-				nodes:              newNodes(2, "fakeID"),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
-				machineSets:        newMachineSets(1, "machinedeployment-1"),
-				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
-				nodeGroups:         []string{nodeGroup1},
+				nodes:       newNodes(2, "fakeID"),
+				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
+				machineSets: newMachineSets(1, "machinedeployment-1"),
+				nodeGroups:  []string{nodeGroup1},
 				controlMachineFakeResourceActions: &customfake.ResourceActions{
 					MachineDeployment: customfake.Actions{
 						Update: customfake.CreateFakeResponse(math.MaxInt32, mdUpdateErrorMsg, 0),
@@ -181,11 +168,10 @@ func TestDeleteNodes(t *testing.T) {
 		{
 			"should scale down when machine deployment update call fails but passes within the timeout period",
 			setup{
-				nodes:              newNodes(2, "fakeID"),
-				machines:           newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
-				machineSets:        newMachineSets(1, "machinedeployment-1"),
-				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
-				nodeGroups:         []string{nodeGroup1},
+				nodes:       newNodes(2, "fakeID"),
+				machines:    newMachines(2, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3", "3"}),
+				machineSets: newMachineSets(1, "machinedeployment-1"),
+				nodeGroups:  []string{nodeGroup1},
 				controlMachineFakeResourceActions: &customfake.ResourceActions{
 					MachineDeployment: customfake.Actions{
 						Update: customfake.CreateFakeResponse(2, mdUpdateErrorMsg, 0),
@@ -194,11 +180,9 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
-				mdName:                                 "machinedeployment-1",
-				mdReplicas:                             1,
-				err:                                    nil,
+				mdName:     "machinedeployment-1",
+				mdReplicas: 1,
+				err:        nil,
 			},
 		},
 		{
@@ -244,10 +228,9 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				prio1Machines: nil,
-				mdName:        "machinedeployment-1",
-				mdReplicas:    1,
-				err:           fmt.Errorf("min size reached, nodes will not be deleted"),
+				mdName:     "machinedeployment-1",
+				mdReplicas: 1,
+				err:        fmt.Errorf("min size reached, nodes will not be deleted"),
 			},
 		},
 		{
@@ -261,10 +244,9 @@ func TestDeleteNodes(t *testing.T) {
 			},
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
-				prio1Machines: nil,
-				mdName:        "machinedeployment-2",
-				mdReplicas:    2,
-				err:           fmt.Errorf("node-1 belongs to a different MachineDeployment than %q", "machinedeployment-1"),
+				mdName:     "machinedeployment-2",
+				mdReplicas: 2,
+				err:        fmt.Errorf("node-1 belongs to a different MachineDeployment than %q", "machinedeployment-1"),
 			},
 		},
 	}
@@ -302,8 +284,7 @@ func TestDeleteNodes(t *testing.T) {
 			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
-			g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(entry.expect.machinesTriggerDeletionAnnotationValue))
-
+			g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(machineDeployment, generateNames("machine", 1))))
 		})
 	}
 }
@@ -334,7 +315,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), setupObj.machineDeployments[0].Name, metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", 2))
-	g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1))))
+	g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(machineDeployment, generateNames("machine", 1))))
 }
 
 func TestRefresh(t *testing.T) {
@@ -398,8 +379,7 @@ func TestRefresh(t *testing.T) {
 				mcmDeployment:      newMCMDeployment(1),
 			},
 			expect{
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
-				err:                                    nil,
+				err: nil,
 			},
 		},
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -1134,7 +1134,6 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
 
 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
-	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
 
 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
@@ -1150,12 +1149,13 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 		if mdCopy.Annotations == nil {
 			mdCopy.Annotations = make(map[string]string)
 		}
-		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
+		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(mdCopy, uniqueForDeletionSet.UnsortedList())
 		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
 			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
 		}
 		mdCopy.Spec.Replicas = expectedReplicas
 		data.RevisedMachineDeployment = mdCopy
+		mdCopy.Annotations[machineutils.LastReplicaChangeAnnotation] = time.Now().Format(time.RFC3339)
 	}
 	return
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -1159,5 +1159,6 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 		mdCopy.Spec.Replicas = expectedReplicas
 		data.RevisedMachineDeployment = mdCopy
 	}
+
 	return
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -1150,7 +1150,7 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 			mdCopy.Annotations = make(map[string]string)
 		}
 		timestamp := time.Now().Format(time.RFC3339)
-		mdCopy.Annotations[machineutils.LastReplicaChangeAnnotation] = timestamp
+		mdCopy.Annotations[machineutils.LastDeploymentReplicaChangeByScalerTime] = timestamp
 		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(uniqueForDeletionSet.UnsortedList(), timestamp)
 		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != "" {
 			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] += ","

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -1149,11 +1149,13 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 		if mdCopy.Annotations == nil {
 			mdCopy.Annotations = make(map[string]string)
 		}
-		mdCopy.Annotations[machineutils.LastReplicaChangeAnnotation] = time.Now().Format(time.RFC3339)
-		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(mdCopy, uniqueForDeletionSet.UnsortedList())
-		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
+		timestamp := time.Now().Format(time.RFC3339)
+		mdCopy.Annotations[machineutils.LastReplicaChangeAnnotation] = timestamp
+		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(uniqueForDeletionSet.UnsortedList(), timestamp)
+		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != "" {
+			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] += ","
 		}
+		mdCopy.Annotations[machineutils.TriggerDeletionByMCM] += triggerDeletionAnnotValue
 		mdCopy.Spec.Replicas = expectedReplicas
 		data.RevisedMachineDeployment = mdCopy
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -1149,13 +1149,13 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 		if mdCopy.Annotations == nil {
 			mdCopy.Annotations = make(map[string]string)
 		}
+		mdCopy.Annotations[machineutils.LastReplicaChangeAnnotation] = time.Now().Format(time.RFC3339)
 		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(mdCopy, uniqueForDeletionSet.UnsortedList())
 		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
 			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
 		}
 		mdCopy.Spec.Replicas = expectedReplicas
 		data.RevisedMachineDeployment = mdCopy
-		mdCopy.Annotations[machineutils.LastReplicaChangeAnnotation] = time.Now().Format(time.RFC3339)
 	}
 	return
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -20,7 +20,9 @@ import (
 	"errors"
 	"maps"
 	"math/rand/v2"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
@@ -233,7 +235,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, strings.Split(createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion, time.Now().Format(time.RFC3339)), "~")[0], strings.Split(data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		assert.Equal(t, int32(2-len(machineNamesForDeletion)), data.RevisedMachineDeployment.Spec.Replicas)
 	})
@@ -245,7 +247,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, strings.Split(createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion, time.Now().Format(time.RFC3339)), "~")[0], strings.Split(data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
@@ -267,7 +269,6 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1", "n2"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
@@ -288,7 +289,6 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := sets.New("n1", "n2")
 		data := computeScaleDownData(md, machineNamesForDeletion.UnsortedList())
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion.UnsortedList()), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -18,14 +18,15 @@ package mcm
 
 import (
 	"errors"
+	"maps"
+	"math/rand/v2"
+	"testing"
+
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/utils/ptr"
-	"maps"
-	"math/rand/v2"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
@@ -232,7 +233,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		assert.Equal(t, int32(2-len(machineNamesForDeletion)), data.RevisedMachineDeployment.Spec.Replicas)
 	})
@@ -244,7 +245,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
@@ -266,7 +267,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1", "n2"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
@@ -287,7 +288,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := sets.New("n1", "n2")
 		data := computeScaleDownData(md, machineNamesForDeletion.UnsortedList())
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion.UnsortedList()), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(md, machineNamesForDeletion.UnsortedList()), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/aws/aws-sdk-go v1.51.28
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/digitalocean/godo v1.27.0
-	github.com/gardener/machine-controller-manager v0.60.0
+	github.com/gardener/machine-controller-manager v0.61.3
 	github.com/gardener/machine-controller-manager-provider-aws v0.26.0
 	github.com/gardener/machine-controller-manager-provider-azure v0.17.0
 	github.com/gofrs/uuid v4.4.0+incompatible
@@ -294,5 +294,3 @@ replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
 replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
-
-replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260327092326-e3ee51751fb5

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -294,3 +294,5 @@ replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
 replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
+
+replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260316085201-829bf7362f60

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -295,4 +295,4 @@ replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
 
-replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260317071809-88529b790f68
+replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260326151956-5372d661046a

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -295,4 +295,4 @@ replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
 
-replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260326151956-5372d661046a
+replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260327092326-e3ee51751fb5

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -295,4 +295,4 @@ replace k8s.io/cri-client => k8s.io/cri-client v0.34.1
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.34.1
 
-replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260316085201-829bf7362f60
+replace github.com/gardener/machine-controller-manager => github.com/r4mek/machine-controller-manager v0.60.1-0.20260317071809-88529b790f68

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -164,8 +164,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/gardener/machine-controller-manager v0.60.0 h1:aaSE85Yu0hcHYsP5/x1rxWa5o2zhmsmXlKQ+xefHY/Q=
-github.com/gardener/machine-controller-manager v0.60.0/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/gardener/machine-controller-manager-provider-aws v0.26.0 h1:JZYqDs/bGO2vHyi4gp/IZn1+aYvaAi4/+bsEbLrYERE=
 github.com/gardener/machine-controller-manager-provider-aws v0.26.0/go.mod h1:ck5t2eoZmePoAGAxOs2zD/SfnOBJ2/klm0NJaMv+klI=
 github.com/gardener/machine-controller-manager-provider-azure v0.17.0 h1:08vJKLX1eyXTVutzBLgDpblFkBnvAeYoTKD7pFrybBs=
@@ -350,6 +348,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260316085201-829bf7362f60 h1:3+ID9hNamiGWh/mzJzZ9E3lYZnXsp1h0hkh54pIidOg=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260316085201-829bf7362f60/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -164,6 +164,8 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
+github.com/gardener/machine-controller-manager v0.61.3 h1:w0JuHCKLmcK7B8E7mx3TvE3e0hSYwikchsMSiMhocqw=
+github.com/gardener/machine-controller-manager v0.61.3/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/gardener/machine-controller-manager-provider-aws v0.26.0 h1:JZYqDs/bGO2vHyi4gp/IZn1+aYvaAi4/+bsEbLrYERE=
 github.com/gardener/machine-controller-manager-provider-aws v0.26.0/go.mod h1:ck5t2eoZmePoAGAxOs2zD/SfnOBJ2/klm0NJaMv+klI=
 github.com/gardener/machine-controller-manager-provider-azure v0.17.0 h1:08vJKLX1eyXTVutzBLgDpblFkBnvAeYoTKD7pFrybBs=
@@ -348,8 +350,6 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260327092326-e3ee51751fb5 h1:5RDrEZIsjWNvahrH/0/Wo5wnHVKXpbVPCs2Mtfd3owo=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260327092326-e3ee51751fb5/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -348,8 +348,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260316085201-829bf7362f60 h1:3+ID9hNamiGWh/mzJzZ9E3lYZnXsp1h0hkh54pIidOg=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260316085201-829bf7362f60/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260317071809-88529b790f68 h1:iynVCWVYkX+Ll515Jubw4ffG/o1ZlRUUBvcY3bR3GRM=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260317071809-88529b790f68/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -348,8 +348,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260317071809-88529b790f68 h1:iynVCWVYkX+Ll515Jubw4ffG/o1ZlRUUBvcY3bR3GRM=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260317071809-88529b790f68/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260326151956-5372d661046a h1:TbqF1GB/SYoOVnV0hCUqBaaTlpICysF7iNEw5eaclkM=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260326151956-5372d661046a/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/cluster-autoscaler/go.sum
+++ b/cluster-autoscaler/go.sum
@@ -348,8 +348,8 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260326151956-5372d661046a h1:TbqF1GB/SYoOVnV0hCUqBaaTlpICysF7iNEw5eaclkM=
-github.com/r4mek/machine-controller-manager v0.60.1-0.20260326151956-5372d661046a/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260327092326-e3ee51751fb5 h1:5RDrEZIsjWNvahrH/0/Wo5wnHVKXpbVPCs2Mtfd3owo=
+github.com/r4mek/machine-controller-manager v0.60.1-0.20260327092326-e3ee51751fb5/go.mod h1:8eE1qLztrWIbOM71mHSQGaC6Q+pl5lvOyN08qP39D7o=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR contains a fix for the issue where a rapid scale up and scale down can result in a cordoned machine in the cluster.

The case happens when CA scales down a MCD followed quickly with scaling up the same MCD before the MCD controller notices the replica change and start reconciliation. The result is the MCD ending up with the same number of replicas that it started off with, causing the MCD controller not to have any work to do since from it's point of view, the MCD replicas have not changed.
As part of the scale down operation, CA will cordon an underutilised node. This node just remains part of the cluster as MCM makes no further attempt to remove it

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/machine-controller-manager/issues/1085

**Special notes for your reviewer**:
There is also a PR raised on `gardener/machine-controller-manager` which has the changes from the MCM and is also required to fix the issue. PR(https://github.com/gardener/machine-controller-manager/pull/1087)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixing the issue where a rapid scale up and scale down can result in a cordoned machine in the cluster
```
