### PR TITLE
Report `InstanceErrorInfo` for all failed machine creation operations

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 
 	v1 "k8s.io/api/apps/v1"
 
@@ -491,8 +492,7 @@ func TestNodes(t *testing.T) {
 					{placeholderInstanceIDForMachineObj("machine-with-vm-but-no-node"), cloudprovider.InstanceState(-1), cloudprovider.InstanceErrorClass(-1), "", ""},
 					{placeholderInstanceIDForMachineObj("machine-with-vm-creating"), cloudprovider.InstanceState(-1), cloudprovider.InstanceErrorClass(-1), "", ""},
 					{placeholderInstanceIDForMachineObj("machine-with-vm-create-error-out-of-quota"), cloudprovider.InstanceCreating, cloudprovider.OutOfResourcesErrorClass, machinecodes.ResourceExhausted.String(), outOfQuotaMachineStatusErrorDescription},
-					// invalid credentials error is mapped to Internal code as it can't be fixed by trying another zone
-					{placeholderInstanceIDForMachineObj("machine-with-vm-create-error-invalid-credentials"), cloudprovider.InstanceState(-1), cloudprovider.InstanceErrorClass(-1), "", ""},
+					{placeholderInstanceIDForMachineObj("machine-with-vm-create-error-invalid-credentials"), cloudprovider.InstanceCreating, cloudprovider.OtherErrorClass, machinecodes.Internal.String(), invalidCredentialsMachineStatusErrorDescription},
 				},
 			},
 		},
@@ -684,6 +684,151 @@ func TestGetOptions(t *testing.T) {
 				g.Expect(*options).To(HaveField("ScaleDownUnneededTime", entry.expect.ngOptions.ScaleDownUnneededTime))
 				g.Expect(*options).To(HaveField("ScaleDownUnreadyTime", entry.expect.ngOptions.ScaleDownUnreadyTime))
 				g.Expect(*options).To(HaveField("MaxNodeProvisionTime", entry.expect.ngOptions.MaxNodeProvisionTime))
+			}
+		})
+	}
+}
+
+func TestGenerateInstanceStatus(t *testing.T) {
+	type expect struct {
+		instanceStatus *cloudprovider.InstanceStatus
+	}
+	type data struct {
+		name    string
+		machine *v1alpha1.Machine
+		expect  expect
+	}
+	table := []data{
+		{
+			"should return InstanceStatus with OutOfResourcesErrorClass for ResourceExhausted create failure",
+			&v1alpha1.Machine{
+				Status: v1alpha1.MachineStatus{
+					LastOperation: v1alpha1.LastOperation{
+						Type:        v1alpha1.MachineOperationCreate,
+						State:       v1alpha1.MachineStateFailed,
+						ErrorCode:   machinecodes.ResourceExhausted.String(),
+						Description: "quota exceeded",
+					},
+				},
+			},
+			expect{
+				instanceStatus: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
+					ErrorInfo: &cloudprovider.InstanceErrorInfo{
+						ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
+						ErrorCode:    machinecodes.ResourceExhausted.String(),
+						ErrorMessage: "quota exceeded",
+					},
+				},
+			},
+		},
+		{
+			"should return InstanceStatus with OtherErrorClass for Internal create failure",
+			&v1alpha1.Machine{
+				Status: v1alpha1.MachineStatus{
+					LastOperation: v1alpha1.LastOperation{
+						Type:        v1alpha1.MachineOperationCreate,
+						State:       v1alpha1.MachineStateFailed,
+						ErrorCode:   machinecodes.Internal.String(),
+						Description: "user is not authorized",
+					},
+				},
+			},
+			expect{
+				instanceStatus: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
+					ErrorInfo: &cloudprovider.InstanceErrorInfo{
+						ErrorClass:   cloudprovider.OtherErrorClass,
+						ErrorCode:    machinecodes.Internal.String(),
+						ErrorMessage: "user is not authorized",
+					},
+				},
+			},
+		},
+		{
+			"should return InstanceStatus with OtherErrorClass for DeadlineExceeded create failure",
+			&v1alpha1.Machine{
+				Status: v1alpha1.MachineStatus{
+					LastOperation: v1alpha1.LastOperation{
+						Type:        v1alpha1.MachineOperationCreate,
+						State:       v1alpha1.MachineStateFailed,
+						ErrorCode:   machinecodes.DeadlineExceeded.String(),
+						Description: "deadline exceeded while creating machine",
+					},
+				},
+			},
+			expect{
+				instanceStatus: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
+					ErrorInfo: &cloudprovider.InstanceErrorInfo{
+						ErrorClass:   cloudprovider.OtherErrorClass,
+						ErrorCode:    machinecodes.DeadlineExceeded.String(),
+						ErrorMessage: "deadline exceeded while creating machine",
+					},
+				},
+			},
+		},
+		{
+			"should return InstanceStatus without ErrorInfo for non-failed create operation",
+			&v1alpha1.Machine{
+				Status: v1alpha1.MachineStatus{
+					LastOperation: v1alpha1.LastOperation{
+						Type:  v1alpha1.MachineOperationCreate,
+						State: v1alpha1.MachineStateProcessing,
+					},
+				},
+			},
+			expect{
+				instanceStatus: &cloudprovider.InstanceStatus{
+					State: cloudprovider.InstanceCreating,
+				},
+			},
+		},
+		{
+			"should return nil for non-create operation",
+			&v1alpha1.Machine{
+				Status: v1alpha1.MachineStatus{
+					LastOperation: v1alpha1.LastOperation{
+						Type:      v1alpha1.MachineOperationDelete,
+						State:     v1alpha1.MachineStateFailed,
+						ErrorCode: machinecodes.Internal.String(),
+					},
+				},
+			},
+			expect{
+				instanceStatus: nil,
+			},
+		},
+		{
+			"should return nil for zero-value last operation",
+			&v1alpha1.Machine{},
+			expect{
+				instanceStatus: nil,
+			},
+		},
+	}
+
+	for _, entry := range table {
+		entry := entry
+		t.Run(entry.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+
+			status := generateInstanceStatus(entry.machine)
+
+			if entry.expect.instanceStatus == nil {
+				g.Expect(status).To(BeNil())
+			} else {
+				g.Expect(status).ToNot(BeNil())
+				g.Expect(status.State).To(Equal(entry.expect.instanceStatus.State))
+				if entry.expect.instanceStatus.ErrorInfo == nil {
+					g.Expect(status.ErrorInfo).To(BeNil())
+				} else {
+					g.Expect(status.ErrorInfo).ToNot(BeNil())
+					g.Expect(status.ErrorInfo.ErrorClass).To(Equal(entry.expect.instanceStatus.ErrorInfo.ErrorClass))
+					g.Expect(status.ErrorInfo.ErrorCode).To(Equal(entry.expect.instanceStatus.ErrorInfo.ErrorCode))
+					g.Expect(status.ErrorInfo.ErrorMessage).To(Equal(entry.expect.instanceStatus.ErrorInfo.ErrorMessage))
+				}
 			}
 		})
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -618,7 +618,7 @@ func findMatchingInstance(nodes []*v1.Node, machine *v1alpha1.Machine) cloudprov
 	//	- the VM is up but has not registered yet
 
 	// Report instance with a special placeholder ID so that the autoscaler can track it as an unregistered node.
-	// Report InstanceStatus only for `ResourceExhausted` errors
+	// Report InstanceStatus for all failed create operations errors
 	return cloudprovider.Instance{
 		Id:     placeholderInstanceIDForMachineObj(machine.Name),
 		Status: generateInstanceStatus(machine),

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -632,12 +632,16 @@ func placeholderInstanceIDForMachineObj(name string) string {
 // generateInstanceStatus returns cloudprovider.InstanceStatus for the machine obj
 func generateInstanceStatus(machine *v1alpha1.Machine) *cloudprovider.InstanceStatus {
 	if machine.Status.LastOperation.Type == v1alpha1.MachineOperationCreate {
-		if machine.Status.LastOperation.State == v1alpha1.MachineStateFailed && machine.Status.LastOperation.ErrorCode == machinecodes.ResourceExhausted.String() {
+		if machine.Status.LastOperation.State == v1alpha1.MachineStateFailed {
+			errorClass := cloudprovider.OtherErrorClass
+			if machine.Status.LastOperation.ErrorCode == machinecodes.ResourceExhausted.String() {
+				errorClass = cloudprovider.OutOfResourcesErrorClass
+			}
 			return &cloudprovider.InstanceStatus{
 				State: cloudprovider.InstanceCreating,
 				ErrorInfo: &cloudprovider.InstanceErrorInfo{
-					ErrorClass:   cloudprovider.OutOfResourcesErrorClass,
-					ErrorCode:    machinecodes.ResourceExhausted.String(),
+					ErrorClass:   errorClass,
+					ErrorCode:    machine.Status.LastOperation.ErrorCode,
 					ErrorMessage: machine.Status.LastOperation.Description,
 				},
 			}


### PR DESCRIPTION
# Report InstanceErrorInfo for all failed machine creation operations

**What this PR does / why we need it**:

`generateInstanceStatus()` only reports `InstanceErrorInfo` when a machine creation fails with `ResourceExhausted`. For any other error code the failed machine is reported as plain `InstanceCreating` with no error details. This means the cluster-autoscaler's backoff mechanism never triggers for non-`ResourceExhausted` failures, and the autoscaler keeps retrying the same failing node group instead of backing off and considering alternatives.

This PR changes `generateInstanceStatus()` to report `InstanceErrorInfo` for **all** failed create operations:
- `ResourceExhausted` errors get `OutOfResourcesErrorClass` (same as before).
- All other errors get `OtherErrorClass`.
- The actual `ErrorCode` from the machine status is propagated instead of hardcoding `ResourceExhausted`.


**Special notes for your reviewer**:

The change is backward-compatible: `ResourceExhausted` failures produce the exact same `InstanceStatus` as before. The only difference is that other failure types now also carry error information, enabling the autoscaler to back off properly.

**Release note**:

```bugfix operator
The MCM cloud provider now reports error information for all failed machine creation operations, not only for `ResourceExhausted`. This enables the cluster-autoscaler backoff mechanism to work correctly for any creation failure, preventing repeated retries against a failing node group.
```
