### PR TITLE
[rel-v1.30] Fixing the issue where a rapid scale up and scale down can result in a cordoned machine in the cluster

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
     with:
       mode: ${{ inputs.mode }}
     permissions:
-      contents: read
+      id-token: write
 
   oci-images:
     name: Build OCI-Images

--- a/.github/workflows/gardener-release.yaml
+++ b/.github/workflows/gardener-release.yaml
@@ -12,8 +12,9 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yaml
+    secrets: inherit
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
     with:
@@ -31,5 +32,4 @@ jobs:
     with:
       release-commit-target: branch
       next-version: ${{ inputs.next-version }}
-      next-version-callback-action-path:
       slack-channel-id: C0170QTBJUW # #gardener-mcm

--- a/.github/workflows/non-release.yaml
+++ b/.github/workflows/non-release.yaml
@@ -10,7 +10,7 @@ jobs:
       mode: snapshot
     secrets: inherit
     permissions:
-      contents: write
+      contents: read
       packages: write
       id-token: write
 
@@ -18,7 +18,6 @@ jobs:
     uses: gardener/cc-utils/.github/workflows/post-build.yaml@master
     needs:
       - build
-    secrets: inherit
     permissions:
       id-token: write
       contents: write

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -565,16 +565,26 @@ func (ngImpl *nodeGroup) AtomicIncreaseSize(delta int) error {
 }
 
 // getMachineNamesTriggeredForDeletion returns the set of machine names contained within the machineutils.TriggerDeletionByMCM annotation on the given MachineDeployment
-// TODO: Move to using MCM annotations.GetMachineNamesTriggeredForDeletion after MCM release.
 func getMachineNamesTriggeredForDeletion(mcd *v1alpha1.MachineDeployment) []string {
-	if mcd.Annotations == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
+	if mcd == nil || mcd.Annotations[machineutils.TriggerDeletionByMCM] == "" {
 		return nil
 	}
-	return strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
+	machineNamesWithTimestamps := strings.Split(mcd.Annotations[machineutils.TriggerDeletionByMCM], ",")
+	machineNames := make([]string, 0, len(machineNamesWithTimestamps))
+	for _, machineNameWithTimestamp := range machineNamesWithTimestamps {
+		parts := strings.Split(machineNameWithTimestamp, "~")
+		if len(parts) != 1 && len(parts) != 2 {
+			klog.Errorf("unexpected format for machineNameWithTimestamp %q in annotation %q of MachineDeployment %q, expected format is <machineName>~<timestamp>", machineNameWithTimestamp, machineutils.TriggerDeletionByMCM, mcd.Name)
+			continue
+		}
+		machineNames = append(machineNames, parts[0])
+	}
+	return machineNames
 }
 
-// TODO: Move to using MCM annotations.CreateMachinesTriggeredForDeletionAnnotValue after MCM release
-func createMachinesTriggeredForDeletionAnnotValue(machineNames []string) string {
+// createMachinesTriggeredForDeletionAnnotValue creates the value for the machineutils.TriggerDeletionByMCM annotation based on the given machine names and timestamp.
+// The format of the returned string is expected to be <machineName1>~<timestamp>,<machineName2>~<timestamp>...
+func createMachinesTriggeredForDeletionAnnotValue(machineNames []string, timestamp string) string {
 	slices.Sort(machineNames)
-	return strings.Join(machineNames, ",")
+	return strings.Join(machineNames, fmt.Sprintf("~%s,", timestamp)) + fmt.Sprintf("~%s", timestamp)
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -8,11 +8,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"math"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 
 	v1 "k8s.io/api/apps/v1"
 
@@ -112,7 +113,7 @@ func TestDeleteNodes(t *testing.T) {
 			expect{
 				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
 				mdName:                                 "machinedeployment-1",
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)),
 				mdReplicas:                             1,
 				err:                                    nil,
 			},
@@ -129,7 +130,7 @@ func TestDeleteNodes(t *testing.T) {
 			action{node: newNode("node-1", "requested://machine-1")},
 			expect{
 				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)),
 				mdName:                                 "machinedeployment-1",
 				mdReplicas:                             0,
 				err:                                    nil,
@@ -194,7 +195,7 @@ func TestDeleteNodes(t *testing.T) {
 			action{node: newNodes(1, "fakeID")[0]},
 			expect{
 				prio1Machines:                          newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"1"}),
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
+				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)),
 				mdName:                                 "machinedeployment-1",
 				mdReplicas:                             1,
 				err:                                    nil,
@@ -301,8 +302,7 @@ func TestDeleteNodes(t *testing.T) {
 			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
-			g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(entry.expect.machinesTriggerDeletionAnnotationValue))
-
+			g.Expect(strings.Split(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0]).To(Equal(strings.Split(entry.expect.machinesTriggerDeletionAnnotationValue, "~")[0]))
 		})
 	}
 }
@@ -333,7 +333,7 @@ func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), setupObj.machineDeployments[0].Name, metav1.GetOptions{})
 	g.Expect(err).ToNot(HaveOccurred())
 	g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", 2))
-	g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(Equal(createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1))))
+	g.Expect(strings.Split(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0]).To(Equal(strings.Split(createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1), time.Now().Format(time.RFC3339)), "~")[0]))
 }
 
 func TestRefresh(t *testing.T) {
@@ -397,8 +397,7 @@ func TestRefresh(t *testing.T) {
 				mcmDeployment:      newMCMDeployment(1),
 			},
 			expect{
-				machinesTriggerDeletionAnnotationValue: createMachinesTriggeredForDeletionAnnotValue(generateNames("machine", 1)),
-				err:                                    nil,
+				err: nil,
 			},
 		},
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -106,6 +106,9 @@ const (
 	machineDeploymentNameLabel = "name"
 	// poolNameLabel is the name of the label for gardener worker pool
 	poolNameLabel = "worker.gardener.cloud/pool"
+
+	// LastDeploymentReplicaChangeByScalerTime is the annotation used to specify the time when machineDeployment replica change was triggered by a scaler.
+	LastDeploymentReplicaChangeByScalerTime = "machine.sapcloud.io/last-deployment-replica-change-by-scaler-time"
 )
 
 var (
@@ -1112,7 +1115,6 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 	alreadyMarkedSet := sets.New(getMachineNamesTriggeredForDeletion(md)...)
 
 	uniqueForDeletionSet := forDeletionSet.Difference(alreadyMarkedSet)
-	toBeMarkedSet := alreadyMarkedSet.Union(forDeletionSet)
 
 	data.RevisedToBeDeletedMachineNames = uniqueForDeletionSet
 	data.RevisedScaledownAmount = uniqueForDeletionSet.Len()
@@ -1128,12 +1130,16 @@ func computeScaleDownData(md *v1alpha1.MachineDeployment, machineNamesForDeletio
 		if mdCopy.Annotations == nil {
 			mdCopy.Annotations = make(map[string]string)
 		}
-		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(toBeMarkedSet.UnsortedList())
-		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != triggerDeletionAnnotValue {
-			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] = triggerDeletionAnnotValue
+		timestamp := time.Now().Format(time.RFC3339)
+		mdCopy.Annotations[LastDeploymentReplicaChangeByScalerTime] = timestamp
+		triggerDeletionAnnotValue := createMachinesTriggeredForDeletionAnnotValue(uniqueForDeletionSet.UnsortedList(), timestamp)
+		if mdCopy.Annotations[machineutils.TriggerDeletionByMCM] != "" {
+			mdCopy.Annotations[machineutils.TriggerDeletionByMCM] += ","
 		}
+		mdCopy.Annotations[machineutils.TriggerDeletionByMCM] += triggerDeletionAnnotValue
 		mdCopy.Spec.Replicas = expectedReplicas
 		data.RevisedMachineDeployment = mdCopy
 	}
+
 	return
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager_test.go
@@ -18,14 +18,17 @@ package mcm
 
 import (
 	"errors"
+	"maps"
+	"math/rand/v2"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/gardener/machine-controller-manager/pkg/util/provider/machineutils"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/autoscaler/cluster-autoscaler/utils/gpu"
 	"k8s.io/utils/ptr"
-	"maps"
-	"math/rand/v2"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 	apiv1 "k8s.io/api/core/v1"
@@ -232,7 +235,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, strings.Split(createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion, time.Now().Format(time.RFC3339)), "~")[0], strings.Split(data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		assert.Equal(t, int32(2-len(machineNamesForDeletion)), data.RevisedMachineDeployment.Spec.Replicas)
 	})
@@ -244,7 +247,7 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
+		assert.Equal(t, strings.Split(createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion, time.Now().Format(time.RFC3339)), "~")[0], strings.Split(data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM], "~")[0])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
@@ -266,7 +269,6 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := []string{"n1", "n2"}
 		data := computeScaleDownData(md, machineNamesForDeletion)
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)
@@ -287,7 +289,6 @@ func TestComputeScaledownData(t *testing.T) {
 
 		machineNamesForDeletion := sets.New("n1", "n2")
 		data := computeScaleDownData(md, machineNamesForDeletion.UnsortedList())
-		assert.Equal(t, createMachinesTriggeredForDeletionAnnotValue(machineNamesForDeletion.UnsortedList()), data.RevisedMachineDeployment.Annotations[machineutils.TriggerDeletionByMCM])
 		assert.Equal(t, len(machineNamesForDeletion), data.RevisedScaledownAmount)
 		expectedReplicas := int32(initialReplicas - len(machineNamesForDeletion))
 		assert.Equal(t, expectedReplicas, data.RevisedMachineDeployment.Spec.Replicas)

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -48,7 +48,6 @@ require (
 	k8s.io/client-go v0.30.1
 	k8s.io/cloud-provider v0.30.1
 	k8s.io/cloud-provider-aws v1.27.0
-	k8s.io/code-generator v0.30.1
 	k8s.io/component-base v0.30.1
 	k8s.io/component-helpers v0.30.1
 	k8s.io/klog/v2 v2.120.1
@@ -57,7 +56,6 @@ require (
 	k8s.io/legacy-cloud-providers v0.0.0
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/cloud-provider-azure v1.28.0
-	sigs.k8s.io/structured-merge-diff/v4 v4.4.1
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -187,6 +185,7 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.3 // indirect
+	k8s.io/code-generator v0.30.1 // indirect
 	k8s.io/controller-manager v0.30.1 // indirect
 	k8s.io/cri-api v0.30.1 // indirect
 	k8s.io/csi-translation-lib v0.27.0 // indirect
@@ -199,6 +198,7 @@ require (
 	k8s.io/mount-utils v0.26.0-alpha.0 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.29.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )
 
 replace github.com/aws/aws-sdk-go/service/eks => github.com/aws/aws-sdk-go/service/eks v1.38.49


### PR DESCRIPTION
**What this PR does / why we need it**:
This is a cherry pick PR of #401 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator github.com/gardener/autoscaler #406 @r4mek
Fixing the issue where a rapid scale up and scale down can result in a cordoned machine in the cluster
```
