### PR TITLE
Skip deletion of  preserved machines with unregistered nodes

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -409,6 +409,9 @@ func (ngImpl *nodeGroup) DeleteNodes(nodes []*apiv1.Node) error {
 // ForceDeleteNodes deletes the nodes from the group without checking for minSize constraint.
 // It's expected that the method won't be called for nodes that aren't part of ANY machine deployment.
 func (ngImpl *nodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
+	if len(nodes) == 0 {
+		return nil
+	}
 	var toBeDeletedMachineInfos = make([]machineInfo, 0, len(nodes))
 	for _, node := range nodes {
 		belongs, mInfo, err := ngImpl.belongs(node)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -428,6 +428,9 @@ func (ngImpl *nodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 		}
 		toBeDeletedMachineInfos = append(toBeDeletedMachineInfos, *mInfo)
 	}
+	if len(toBeDeletedMachineInfos) == 0 {
+		return ErrNoNodesToDelete
+	}
 	return ngImpl.deleteMachines(toBeDeletedMachineInfos)
 }
 

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -23,6 +23,7 @@ package mcm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -41,7 +42,7 @@ import (
 	"k8s.io/autoscaler/cluster-autoscaler/cloudprovider"
 	"k8s.io/autoscaler/cluster-autoscaler/config"
 	"k8s.io/autoscaler/cluster-autoscaler/simulator/framework"
-	"k8s.io/autoscaler/cluster-autoscaler/utils/errors"
+	caerrors "k8s.io/autoscaler/cluster-autoscaler/utils/errors"
 	"k8s.io/klog/v2"
 )
 
@@ -68,6 +69,10 @@ const (
 	// MaxNodeProvisionTimeAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.MaxNodeProvisionTime
 	MaxNodeProvisionTimeAnnotation = "autoscaler.gardener.cloud/max-node-provision-time"
 )
+
+// ErrNoNodesToDelete is a sentinel error that indicates that nodes could not be deleted either due to machine being in Failed or Terminating phase,
+// because machine was preserved or because the node was annotated with scale-down-disabled=true
+var ErrNoNodesToDelete = errors.New("no nodes deleted: all candidates skipped due to termination, preservation, or scale-down-disabled annotation")
 
 // MCMCloudProvider implements the cloud provider interface for machine-controller-manager
 // Reference: https://github.com/gardener/machine-controller-manager
@@ -173,7 +178,7 @@ func (mcm *mcmCloudProvider) HasInstance(*apiv1.Node) (bool, error) {
 }
 
 // Pricing returns pricing model for this cloud provider or error if not available.
-func (mcm *mcmCloudProvider) Pricing() (cloudprovider.PricingModel, errors.AutoscalerError) {
+func (mcm *mcmCloudProvider) Pricing() (cloudprovider.PricingModel, caerrors.AutoscalerError) {
 	return nil, cloudprovider.ErrNotImplemented
 }
 
@@ -412,19 +417,19 @@ func (ngImpl *nodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 		} else if !belongs {
 			return fmt.Errorf("%s belongs to a different MachineDeployment than %q", node.Name, ngImpl.Name)
 		}
-		if mInfo.MachinePreserved {
+		// Failed machines that are preserved are covered by the first case.
+		// If the machine is not preserved, but is in failed state, the second case is executed.
+		// The ordering of the cases needs to be maintained for accurate logging.
+		switch {
+		case mInfo.MachinePreserved:
 			klog.V(3).Infof("for NodeGroup %q, Node %q corresponding to Machine %q is marked as preserved - skipping deletion", ngImpl.Name, node.Name, mInfo.Key.Name)
-			continue
-		}
-		if mInfo.FailedOrTerminating {
+		case mInfo.FailedOrTerminating:
 			klog.V(3).Infof("for NodeGroup %q, Machine %q is already marked as terminating - skipping deletion", ngImpl.Name, mInfo.Key.Name)
-			continue
-		}
-		if eligibility.HasNoScaleDownAnnotation(node) {
+		case eligibility.HasNoScaleDownAnnotation(node):
 			klog.V(3).Infof("for NodeGroup %q, Node %q corresponding to Machine %q is marked with ScaleDownDisabledAnnotation %q - skipping deletion", ngImpl.Name, node.Name, mInfo.Key.Name, eligibility.ScaleDownDisabledKey)
-			continue
+		default:
+			toBeDeletedMachineInfos = append(toBeDeletedMachineInfos, *mInfo)
 		}
-		toBeDeletedMachineInfos = append(toBeDeletedMachineInfos, *mInfo)
 	}
 	if len(toBeDeletedMachineInfos) == 0 {
 		return ErrNoNodesToDelete

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -412,18 +412,16 @@ func (ngImpl *nodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 		} else if !belongs {
 			return fmt.Errorf("%s belongs to a different MachineDeployment than %q", node.Name, ngImpl.Name)
 		}
+		if mInfo.MachinePreserved {
+			klog.V(3).Infof("for NodeGroup %q, Node %q corresponding to Machine %q is marked as preserved - skipping deletion", ngImpl.Name, node.Name, mInfo.Key.Name)
+			continue
+		}
 		if mInfo.FailedOrTerminating {
 			klog.V(3).Infof("for NodeGroup %q, Machine %q is already marked as terminating - skipping deletion", ngImpl.Name, mInfo.Key.Name)
 			continue
 		}
 		if eligibility.HasNoScaleDownAnnotation(node) {
 			klog.V(3).Infof("for NodeGroup %q, Node %q corresponding to Machine %q is marked with ScaleDownDisabledAnnotation %q - skipping deletion", ngImpl.Name, node.Name, mInfo.Key.Name, eligibility.ScaleDownDisabledKey)
-			continue
-		}
-		// If the machine is preserved, has no backing node object, and the VM exists, we need this case to prevent deletion of a preserved machine and the VM.
-		// This is required since there is no node object to annotate with the NoScaleDownAnnotation.
-		if mInfo.MachinePreserved {
-			klog.V(3).Infof("for NodeGroup %q, Machine %q is marked as preserved - skipping deletion", ngImpl.Name, mInfo.Key.Name)
 			continue
 		}
 		toBeDeletedMachineInfos = append(toBeDeletedMachineInfos, *mInfo)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -420,6 +420,12 @@ func (ngImpl *nodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 			klog.V(3).Infof("for NodeGroup %q, Node %q corresponding to Machine %q is marked with ScaleDownDisabledAnnotation %q - skipping deletion", ngImpl.Name, node.Name, mInfo.Key.Name, eligibility.ScaleDownDisabledKey)
 			continue
 		}
+		// If the machine is preserved, has no backing node object, and the VM exists, we need this case to prevent deletion of a preserved machine and the VM.
+		// This is required since there is no node object to annotate with the NoScaleDownAnnotation.
+		if mInfo.MachinePreserved {
+			klog.V(3).Infof("for NodeGroup %q, Machine %q is marked as preserved - skipping deletion", ngImpl.Name, mInfo.Key.Name)
+			continue
+		}
 		toBeDeletedMachineInfos = append(toBeDeletedMachineInfos, *mInfo)
 	}
 	return ngImpl.deleteMachines(toBeDeletedMachineInfos)

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -217,7 +217,7 @@ func TestDeleteNodes(t *testing.T) {
 			expect{
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
-				err:        nil,
+				err:        ErrNoNodesToDelete,
 			},
 		},
 		{
@@ -233,7 +233,7 @@ func TestDeleteNodes(t *testing.T) {
 			expect{
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
-				err:        nil,
+				err:        ErrNoNodesToDelete,
 			},
 		},
 		{
@@ -346,7 +346,7 @@ func TestForceDeleteNodes(t *testing.T) {
 			expect{
 				mdName:     "machinedeployment-1",
 				mdReplicas: 1,
-				err:        nil,
+				err:        ErrNoNodesToDelete,
 			},
 		},
 		{

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -311,6 +311,7 @@ func TestDeleteNodes(t *testing.T) {
 }
 
 func TestForceDeleteNodes(t *testing.T) {
+	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
 	type action struct {
 		nodes []*corev1.Node
 	}

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -315,9 +315,10 @@ func TestForceDeleteNodes(t *testing.T) {
 		nodes []*corev1.Node
 	}
 	type expect struct {
-		mdName     string
-		mdReplicas int32
-		err        error
+		mdName             string
+		mdReplicas         int32
+		deletedMachineName string
+		err                error
 	}
 	type data struct {
 		name   string
@@ -344,9 +345,10 @@ func TestForceDeleteNodes(t *testing.T) {
 			},
 			action{nodes: []*corev1.Node{newNode("node-1", "requested://machine-1")}},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        ErrNoNodesToDelete,
+				mdName:             "machinedeployment-1",
+				mdReplicas:         1,
+				deletedMachineName: "",
+				err:                ErrNoNodesToDelete,
 			},
 		},
 		{
@@ -360,9 +362,10 @@ func TestForceDeleteNodes(t *testing.T) {
 			},
 			action{nodes: []*corev1.Node{newNode("node-1", "requested://machine-1")}},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 0,
-				err:        nil,
+				mdName:             "machinedeployment-1",
+				mdReplicas:         0,
+				deletedMachineName: "machine-1",
+				err:                nil,
 			},
 		},
 		{
@@ -385,9 +388,10 @@ func TestForceDeleteNodes(t *testing.T) {
 				newNode("node-2", "requested://machine-2"),
 			}},
 			expect{
-				mdName:     "machinedeployment-1",
-				mdReplicas: 1,
-				err:        nil,
+				mdName:             "machinedeployment-1",
+				mdReplicas:         1,
+				deletedMachineName: "machine-2",
+				err:                nil,
 			},
 		},
 	}
@@ -418,6 +422,7 @@ func TestForceDeleteNodes(t *testing.T) {
 			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
+			g.Expect(machineDeployment.Annotations[machineutils.TriggerDeletionByMCM]).To(ContainSubstring(entry.expect.deletedMachineName))
 		})
 	}
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -366,7 +366,7 @@ func TestForceDeleteNodes(t *testing.T) {
 			},
 		},
 		{
-			"should only delete non-preserved machines when mix of preserved and non-preserved unregistered nodes",
+			"should only delete non-preserved machines when there's a mix of preserved and non-preserved unregistered nodes",
 			setup{
 				nodes: nil,
 				machines: func() []*v1alpha1.Machine {

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -310,6 +310,118 @@ func TestDeleteNodes(t *testing.T) {
 	}
 }
 
+func TestForceDeleteNodes(t *testing.T) {
+	type action struct {
+		nodes []*corev1.Node
+	}
+	type expect struct {
+		mdName     string
+		mdReplicas int32
+		err        error
+	}
+	type data struct {
+		name   string
+		setup  setup
+		action action
+		expect expect
+	}
+
+	preservedMachineStatus := &v1alpha1.MachineStatus{
+		CurrentStatus: v1alpha1.CurrentStatus{
+			PreserveExpiryTime: &metav1.Time{Time: time.Now().Add(1 * time.Hour)},
+		},
+	}
+
+	table := []data{
+		{
+			"should not delete a preserved machine whose backing node is unregistered",
+			setup{
+				nodes:              nil,
+				machines:           newMachines(1, "fakeID", preservedMachineStatus, "machinedeployment-1", "machineset-1", []string{"3"}),
+				machineSets:        newMachineSets(1, "machinedeployment-1"),
+				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
+				nodeGroups:         []string{nodeGroup2},
+			},
+			action{nodes: []*corev1.Node{newNode("node-1", "requested://machine-1")}},
+			expect{
+				mdName:     "machinedeployment-1",
+				mdReplicas: 1,
+				err:        nil,
+			},
+		},
+		{
+			"should delete a non-preserved machine whose backing node is unregistered",
+			setup{
+				nodes:              nil,
+				machines:           newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"}),
+				machineSets:        newMachineSets(1, "machinedeployment-1"),
+				machineDeployments: newMachineDeployments(1, 1, nil, nil, nil),
+				nodeGroups:         []string{nodeGroup2},
+			},
+			action{nodes: []*corev1.Node{newNode("node-1", "requested://machine-1")}},
+			expect{
+				mdName:     "machinedeployment-1",
+				mdReplicas: 0,
+				err:        nil,
+			},
+		},
+		{
+			"should only delete non-preserved machines when mix of preserved and non-preserved unregistered nodes",
+			setup{
+				nodes: nil,
+				machines: func() []*v1alpha1.Machine {
+					preserved := newMachines(1, "fakeID", preservedMachineStatus, "machinedeployment-1", "machineset-1", []string{"3"})
+					nonPreserved := newMachines(1, "fakeID", nil, "machinedeployment-1", "machineset-1", []string{"3"})
+					nonPreserved[0].Name = "machine-2"
+					nonPreserved[0].Spec.ProviderID = "fakeID/i2"
+					return append(preserved, nonPreserved...)
+				}(),
+				machineSets:        newMachineSets(1, "machinedeployment-1"),
+				machineDeployments: newMachineDeployments(1, 2, nil, nil, nil),
+				nodeGroups:         []string{"1:3:" + testNamespace + ".machinedeployment-1"},
+			},
+			action{nodes: []*corev1.Node{
+				newNode("node-1", "requested://machine-1"),
+				newNode("node-2", "requested://machine-2"),
+			}},
+			expect{
+				mdName:     "machinedeployment-1",
+				mdReplicas: 1,
+				err:        nil,
+			},
+		},
+	}
+
+	for _, entry := range table {
+		entry := entry
+		t.Run(entry.name, func(t *testing.T) {
+			t.Parallel()
+			g := NewWithT(t)
+			stop := make(chan struct{})
+			defer close(stop)
+			controlMachineObjects, targetCoreObjects, _ := setupEnv(&entry.setup)
+			m, trackers, hasSyncedCacheFns := createMcmManager(t, stop, testNamespace, entry.setup.nodeGroups, controlMachineObjects, targetCoreObjects, nil)
+			defer trackers.Stop()
+			waitForCacheSync(t, stop, hasSyncedCacheFns)
+
+			mcd, err := buildNodeGroupFromSpec(entry.setup.nodeGroups[0], m)
+			g.Expect(err).To(BeNil())
+
+			err = mcd.ForceDeleteNodes(entry.action.nodes)
+
+			if entry.expect.err != nil {
+				g.Expect(err).To(Equal(entry.expect.err))
+			} else {
+				g.Expect(err).To(BeNil())
+			}
+
+			machineDeployment, err := m.machineClient.MachineDeployments(m.namespace).Get(context.TODO(), entry.expect.mdName, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(machineDeployment.Spec.Replicas).To(BeNumerically("==", entry.expect.mdReplicas))
+		})
+	}
+}
+
 func TestIdempotencyOfDeleteNodes(t *testing.T) {
 	clientfeaturestesting.SetFeatureDuringTest(t, clientfeatures.WatchListClient, false)
 	setupObj := setup{

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -125,9 +125,12 @@ var (
 
 	// ErrInvalidNodeTemplate is a sentinel error that indicates that the nodeTemplate is invalid.
 	ErrInvalidNodeTemplate = errors.New("invalid node template")
-	coreResourceNames      = []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, "gpu"}
-	extraResourceNames     = []v1.ResourceName{gpu.ResourceNvidiaGPU, v1.ResourcePods, v1.ResourceEphemeralStorage}
-	knownResourceNames     = slices.Concat(coreResourceNames, extraResourceNames)
+	//ErrNoNodesToDelete is a sentinel error that indicates that nodes could not be deleted either due to machine being in Failed or Terminating phase,
+	// because machine was preserved or because the node was annotated with scale-down-disabled=true
+	ErrNoNodesToDelete = errors.New("nodes could not be deleted due to ongoing deletion, preservation or because of scale-down-disabled annotation")
+	coreResourceNames  = []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, "gpu"}
+	extraResourceNames = []v1.ResourceName{gpu.ResourceNvidiaGPU, v1.ResourcePods, v1.ResourceEphemeralStorage}
+	knownResourceNames = slices.Concat(coreResourceNames, extraResourceNames)
 )
 
 // McmManager manages the client communication for MachineDeployments.

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -125,12 +125,9 @@ var (
 
 	// ErrInvalidNodeTemplate is a sentinel error that indicates that the nodeTemplate is invalid.
 	ErrInvalidNodeTemplate = errors.New("invalid node template")
-	//ErrNoNodesToDelete is a sentinel error that indicates that nodes could not be deleted either due to machine being in Failed or Terminating phase,
-	// because machine was preserved or because the node was annotated with scale-down-disabled=true
-	ErrNoNodesToDelete = errors.New("nodes could not be deleted due to ongoing deletion, preservation or because of scale-down-disabled annotation")
-	coreResourceNames  = []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, "gpu"}
-	extraResourceNames = []v1.ResourceName{gpu.ResourceNvidiaGPU, v1.ResourcePods, v1.ResourceEphemeralStorage}
-	knownResourceNames = slices.Concat(coreResourceNames, extraResourceNames)
+	coreResourceNames      = []v1.ResourceName{v1.ResourceCPU, v1.ResourceMemory, "gpu"}
+	extraResourceNames     = []v1.ResourceName{gpu.ResourceNvidiaGPU, v1.ResourcePods, v1.ResourceEphemeralStorage}
+	knownResourceNames     = slices.Concat(coreResourceNames, extraResourceNames)
 )
 
 // McmManager manages the client communication for MachineDeployments.
@@ -1045,6 +1042,7 @@ func (m *McmManager) getMachineInfo(node *apiv1.Node) (*machineInfo, error) {
 			nodeID[len(nodeID)-1] == machine.Name {
 			machineName = machine.Name
 			machineNamespace = machine.Namespace
+			// machines that are preserved in failed phase will also have isFailedOrTerminating value set to true.
 			isFailedOrTerminating = isMachineFailedOrTerminating(machine)
 			// Here, we do not check for expiry since MCM handles the removal of preserveExpiryTime on expiry.
 			// Doing the check here and allowing deletion on expiry may lead to race conditions.

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_manager.go
@@ -171,6 +171,7 @@ type machineInfo struct {
 	Key                 types.NamespacedName
 	NodeName            string
 	FailedOrTerminating bool
+	MachinePreserved    bool
 }
 
 func (m machineInfo) String() string {
@@ -1031,7 +1032,7 @@ func (m *McmManager) getMachineInfo(node *apiv1.Node) (*machineInfo, error) {
 
 	providerID := node.Spec.ProviderID
 	var machineName, machineNamespace string
-	var isFailedOrTerminating bool
+	var isFailedOrTerminating, machinePreserved bool
 	for _, machine := range machines {
 		machineID := strings.Split(machine.Spec.ProviderID, "/")
 		nodeID := strings.Split(node.Spec.ProviderID, "/")
@@ -1042,6 +1043,11 @@ func (m *McmManager) getMachineInfo(node *apiv1.Node) (*machineInfo, error) {
 			machineName = machine.Name
 			machineNamespace = machine.Namespace
 			isFailedOrTerminating = isMachineFailedOrTerminating(machine)
+			// Here, we do not check for expiry since MCM handles the removal of preserveExpiryTime on expiry.
+			// Doing the check here and allowing deletion on expiry may lead to race conditions.
+			if !machine.Status.CurrentStatus.PreserveExpiryTime.IsZero() {
+				machinePreserved = true
+			}
 			break
 		}
 	}
@@ -1057,6 +1063,7 @@ func (m *McmManager) getMachineInfo(node *apiv1.Node) (*machineInfo, error) {
 		},
 		NodeName:            node.Name,
 		FailedOrTerminating: isFailedOrTerminating,
+		MachinePreserved:    machinePreserved,
 	}, nil
 }
 

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -319,5 +319,3 @@ replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
 replace k8s.io/cri-client => k8s.io/cri-client v0.35.0
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.35.3
-
-replace github.com/gardener/machine-controller-manager => github.com/gardener/machine-controller-manager v0.62.0

--- a/cluster-autoscaler/go.mod
+++ b/cluster-autoscaler/go.mod
@@ -319,3 +319,5 @@ replace k8s.io/autoscaler/cluster-autoscaler/apis => ./apis
 replace k8s.io/cri-client => k8s.io/cri-client v0.35.0
 
 replace k8s.io/externaljwt => k8s.io/externaljwt v0.35.3
+
+replace github.com/gardener/machine-controller-manager => github.com/gardener/machine-controller-manager v0.62.0


### PR DESCRIPTION
**What this PR does / why we need it**:

When a machine's node is unregistered, CA creates a fake backing node to track how long the node has been unregistered . However, if this machine is preserved, since there is no real backing node and there is no scale-down-disabled annotation added to the fake node, CA marks the machine object for deletion which results in the removal of both machine object and VM. This is not the desired behaviour since operators may wish to debug the issue without deleting the machine and VM.

The PR modifies ForceDeleteNodes to skip a node (even fake ones) if the corresponding machine is preserved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR needs to be modified after MCM release is made with preservation feature to update the MCM version in `go.mod`.

The change was validated using MCM's provider virtual.

```
I0421 11:09:04.669875   60698 clusterstate.go:689] Found longUnregistered Nodes [requested://shoot--i544000--awsit-worker-t2gou-z1-5cd54-8xl4h]
I0421 11:09:04.669887   60698 static_autoscaler.go:410] 1 unregistered nodes present
I0421 11:09:04.669893   60698 static_autoscaler.go:858] Marking unregistered node requested://shoot--i544000--awsit-worker-t2gou-z1-5cd54-8xl4h for removal
I0421 11:09:04.669898   60698 static_autoscaler.go:776] Removing 1 unregistered nodes for node group shoot--i544000--awsit-worker-t2gou-z1
I0421 11:09:04.669902   60698 mcm_cloud_provider.go:390] for NodeGroup "shoot--i544000--awsit-worker-t2gou-z1", Received request to delete nodes:- [requested://shoot--i544000--awsit-worker-t2gou-z1-5cd54-8xl4h]
I0421 11:09:04.669908   60698 mcm_cloud_provider.go:423] for NodeGroup "shoot--i544000--awsit-worker-t2gou-z1", Machine "shoot--i544000--awsit-worker-t2gou-z1-5cd54-8xl4h" is marked as preserved - skipping deletion
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Modify ForceDeleteNodes behaviour to skip deletion of preserved machines with unregistered nodes.
```
