### PR TITLE
Fix flaky IT test

### DIFF
--- a/cluster-autoscaler/integration/integration_test.go
+++ b/cluster-autoscaler/integration/integration_test.go
@@ -197,7 +197,9 @@ func (driver *Driver) controllerTests() {
 					driver.targetCluster.getNumberOfReadyNodes,
 					pollingTimeout,
 					pollingInterval).
-					Should(BeNumerically("==", maxNodes))
+					// getNumberOfReadyNodes counts all k8s nodes including the sys-comp node
+					// which is always present but outside CA's managed groups.
+					Should(BeNumerically("==", maxNodes+1))
 			})
 		})
 		Context("by decreasing the workload to below min", func() {


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR includes a flaky test fix from https://github.com/gardener/autoscaler/pull/420 raised by @gagan16k for v1.35.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

UT and IT pass

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
