### PR TITLE
[rel-v1.34] Fix return value of `ForceDeleteNodes` to prevent unintentional reversal of scale down

### DIFF
--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider.go
@@ -23,7 +23,6 @@ package mcm
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -69,10 +68,6 @@ const (
 	// MaxNodeProvisionTimeAnnotation is the annotation key for the value of NodeGroupAutoscalingOptions.MaxNodeProvisionTime
 	MaxNodeProvisionTimeAnnotation = "autoscaler.gardener.cloud/max-node-provision-time"
 )
-
-// ErrNoNodesToDelete is a sentinel error that indicates that nodes could not be deleted either due to machine being in Failed or Terminating phase,
-// because machine was preserved or because the node was annotated with scale-down-disabled=true
-var ErrNoNodesToDelete = errors.New("no nodes deleted: all candidates skipped due to termination, preservation, or scale-down-disabled annotation")
 
 // MCMCloudProvider implements the cloud provider interface for machine-controller-manager
 // Reference: https://github.com/gardener/machine-controller-manager
@@ -430,9 +425,6 @@ func (ngImpl *nodeGroup) ForceDeleteNodes(nodes []*apiv1.Node) error {
 		default:
 			toBeDeletedMachineInfos = append(toBeDeletedMachineInfos, *mInfo)
 		}
-	}
-	if len(toBeDeletedMachineInfos) == 0 {
-		return ErrNoNodesToDelete
 	}
 	return ngImpl.deleteMachines(toBeDeletedMachineInfos)
 }

--- a/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/mcm/mcm_cloud_provider_test.go
@@ -216,7 +216,7 @@ func TestDeleteNodes(t *testing.T) {
 			expect{
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
-				err:        ErrNoNodesToDelete,
+				err:        nil,
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestDeleteNodes(t *testing.T) {
 			expect{
 				mdName:     "machinedeployment-1",
 				mdReplicas: 2,
-				err:        ErrNoNodesToDelete,
+				err:        nil,
 			},
 		},
 		{
@@ -348,7 +348,7 @@ func TestForceDeleteNodes(t *testing.T) {
 				mdName:             "machinedeployment-1",
 				mdReplicas:         1,
 				deletedMachineName: "",
-				err:                ErrNoNodesToDelete,
+				err:                nil,
 			},
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

The PR removes the erroneous sentinel error return from `ForceDeleteNodes`, when no nodes are deleted, that causes CA to reverse its scale down by uncordoning and untainting a node it had previously started to scale down.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
IT passed on GCP

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix bug where returning an error from `ForceDeleteNodes` when no nodes are deleted, causes CA to untaint and uncordon a node that is in the process of scaling down.
```
